### PR TITLE
fix: handle channel reads correctly

### DIFF
--- a/src/derive/stages/batcher_transactions.rs
+++ b/src/derive/stages/batcher_transactions.rs
@@ -30,7 +30,7 @@ impl BatcherTransactions {
     }
 
     fn pull_data(&mut self) {
-        while let Ok(data) = self.tx_recv.try_recv() {
+        for data in self.tx_recv.try_iter() {
             let res = BatcherTransaction::from_data(&data).map(|tx| {
                 self.txs.push(tx);
             });


### PR DESCRIPTION
Fixes a regression introduced in #51 where the channels would miss some L1 data after peeking it. This was due to a misunderstanding of how the peekable iterators work.