### PR TITLE
feat: move final tokio update to tokio task

### DIFF
--- a/src/engine/traits.rs
+++ b/src/engine/traits.rs
@@ -12,7 +12,7 @@ use super::{
 /// This is a modified version of the [Ethereum Execution API Specs](https://github.com/ethereum/execution-apis),
 /// as defined in the [Optimism Exec Engine Specs](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md).
 #[async_trait]
-pub trait L2EngineApi {
+pub trait L2EngineApi: Send + Sync + 'static {
     /// ## forkchoice_updated
     ///
     /// Updates were made to [`engine_forkchoiceUpdatedV1`](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_forkchoiceupdatedv1)


### PR DESCRIPTION
There is no need to block future `advance` calls by waiting for the final `update_forkchoice` update since it will be updated in the next iteration's `build_payload` call. Moving to a tokio task gives us a decent perf improvement.