### PR TITLE
fix: consume all returned logs

### DIFF
--- a/src/l1/mod.rs
+++ b/src/l1/mod.rs
@@ -230,7 +230,7 @@ impl InnerWatcher {
                     .map(|log| UserDeposited::try_from(log).unwrap())
                     .collect::<Vec<UserDeposited>>();
 
-                for num in block_num..end_block {
+                for num in block_num..=end_block {
                     let deposits = deposit_logs
                         .iter()
                         .filter(|d| d.l1_block_num == num)


### PR DESCRIPTION
The last log returned log was not getting consumed which would cause a crash once we hit the finalized chain head.

As of this PR, Magi can stay in sync with the latest finalized block.