### PR TITLE
fix: drop invalid batcher transactions

### DIFF
--- a/src/derive/stages/batcher_transactions.rs
+++ b/src/derive/stages/batcher_transactions.rs
@@ -30,7 +30,7 @@ impl BatcherTransactions {
             });
 
             if res.is_err() {
-                tracing::debug!("Failed to decode batcher transaction");
+                tracing::warn!("dropping invalid batcher transaction");
             }
         }
     }


### PR DESCRIPTION
If a batcher transaction fails to decode, gracefully drop it. This was discovered when Magi attempted to process `0xa43fa9da683a6157a114e3175a625b5aed85d8c573aae226768c58a924a17be0` from base goerli. This batcher transaction seems to be malformed with an extremely long frame data size parameter in its single frame. 