### PR TITLE
feat: use configured blocktime instead of hardcoded values

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,5 +120,6 @@ The [Config](./src/config/mod.rs) object contains the system configuration for t
 - `batch_sender`: The L1 address of the batch sender.
 - `batch_inbox`: The batch inbox address.
 - `deposit_contract`: The L1 address of the deposit contract.
+- `blocktime`: The L2 blocktime.
 
 The [ChainConfig](./src/config/mod.rs) contains default implementations for certain chains. For example, a `goerli` [ChainConfig](./src/config/mod.rs) instance can be created by calling `ChainConfig::goerli()`.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -127,6 +127,9 @@ pub struct ChainConfig {
     pub max_seq_drift: u64,
     /// Timestamp of the regolith hardfork
     pub regolith_time: u64,
+    /// Network blocktime
+    #[serde(default = "default_blocktime")]
+    pub blocktime: u64,
 }
 
 /// Optimism system config contract values
@@ -219,6 +222,7 @@ impl ChainConfig {
             seq_window_size: 3600,
             max_seq_drift: 600,
             regolith_time: 1679079600,
+            blocktime: 2,
         }
     }
     pub fn base_goerli() -> Self {
@@ -249,6 +253,7 @@ impl ChainConfig {
             seq_window_size: 3600,
             max_seq_drift: 600,
             regolith_time: u64::MAX,
+            blocktime: 2,
         }
     }
 }
@@ -269,4 +274,8 @@ fn addr(s: &str) -> Address {
 
 fn hash(s: &str) -> H256 {
     H256::from_str(s).unwrap()
+}
+
+fn default_blocktime() -> u64 {
+    2
 }

--- a/src/derive/stages/batches.rs
+++ b/src/derive/stages/batches.rs
@@ -95,7 +95,7 @@ impl Batches {
 
             if let Some(next_epoch) = next_epoch {
                 if current_l1_block > epoch.number + seq_window_size {
-                    let next_timestamp = safe_head.timestamp + 2;
+                    let next_timestamp = safe_head.timestamp + self.config.chain.blocktime;
                     let epoch = if next_timestamp < next_epoch.timestamp {
                         epoch
                     } else {
@@ -128,7 +128,7 @@ impl Batches {
         let epoch = state.safe_epoch;
         let next_epoch = state.epoch_by_number(epoch.number + 1);
         let head = state.safe_head;
-        let next_timestamp = head.timestamp + 2;
+        let next_timestamp = head.timestamp + self.config.chain.blocktime;
 
         // check timestamp range
         match batch.timestamp.cmp(&next_timestamp) {

--- a/src/driver/engine_driver.rs
+++ b/src/driver/engine_driver.rs
@@ -19,6 +19,8 @@ pub struct EngineDriver<E: Engine> {
     engine: Arc<E>,
     /// Provider for the local L2 execution RPC
     provider: Provider<Http>,
+    /// Blocktime of the L2 chain
+    blocktime: u64,
     /// Most recent block hash that can be derived from L1 data
     pub safe_head: BlockInfo,
     /// Batch epoch of the safe head
@@ -154,7 +156,7 @@ impl<E: Engine> EngineDriver<E> {
 
     async fn block_at(&self, timestamp: u64) -> Option<Block<H256>> {
         let time_diff = timestamp as i64 - self.finalized_head.timestamp as i64;
-        let blocks = time_diff / 2;
+        let blocks = time_diff / self.blocktime as i64;
         let block_num = self.finalized_head.number as i64 + blocks;
         self.provider.get_block(block_num as u64).await.ok()?
     }
@@ -201,6 +203,7 @@ impl EngineDriver<EngineApi> {
         Ok(Self {
             engine,
             provider,
+            blocktime: config.chain.blocktime,
             safe_head: finalized_head,
             safe_epoch: finalized_epoch,
             finalized_head,


### PR DESCRIPTION
As specified in #84, adds the network blocktime as a config value and replaces all blocktime-related uses of `2` (the default value) with the configured blocktime. Also ran `cargo clippy/fmt/test` to make sure all's good on that front!

Closes #84 