### PR TITLE
fix: `peek` method typo

### DIFF
--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -70,7 +70,7 @@ impl Pipeline {
         Ok(())
     }
 
-    pub fn peak(&mut self) -> Option<&PayloadAttributes> {
+    pub fn peek(&mut self) -> Option<&PayloadAttributes> {
         if self.pending_attributes.is_none() {
             let next_attributes = self.next();
             self.pending_attributes = next_attributes;


### PR DESCRIPTION
It seems to me like the intention was for the method to be similar to [`Peekable`](https://doc.rust-lang.org/stable/std/iter/struct.Peekable.html)