### PR TITLE
Feat: store debug logs in files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,7 +1804,7 @@ dependencies = [
  "sled",
  "tokio",
  "tracing",
- "tracing-log",
+ "tracing-appender",
  "tracing-subscriber",
  "uuid 1.3.0",
 ]
@@ -3222,6 +3232,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time 0.3.20",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ openssl = { version = "0.10", features = ["vendored"] }
 chrono = "0.4.22"
 tracing = "0.1.36"
 ansi_term = "0.12.1"
-tracing-log = "0.1.3"
-tracing-subscriber = { version = "0.3.16", features = ["fmt", "env-filter", "ansi"] }
+tracing-appender = "0.2.2"
+tracing-subscriber = { version = "0.3.16", features = ["fmt", "env-filter", "ansi", "tracing-log"] }
 prometheus_exporter = "0.8.5"
 lazy_static = "1.4.0"
 

--- a/bin/magi.rs
+++ b/bin/magi.rs
@@ -16,9 +16,11 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     let sync_mode = cli.sync_mode.clone();
     let verbose = cli.verbose;
+    let logs_dir = cli.logs_dir.clone();
+    let logs_rotation = cli.logs_rotation.clone();
     let config = cli.to_config();
 
-    telemetry::init(verbose)?;
+    let _guards = telemetry::init(verbose, logs_dir, logs_rotation);
     metrics::init()?;
 
     match sync_mode {
@@ -69,6 +71,10 @@ pub struct Cli {
     jwt_secret: Option<String>,
     #[clap(short = 'v', long)]
     verbose: bool,
+    #[clap(long)]
+    logs_dir: Option<String>,
+    #[clap(long)]
+    logs_rotation: Option<String>,
 }
 
 impl Cli {

--- a/docker/start-magi.sh
+++ b/docker/start-magi.sh
@@ -10,4 +10,6 @@ exec magi \
     --l2-rpc-url http://op-geth:8545 \
     --l2-engine-url http://op-geth:8551 \
     --data-dir $DATADIR \
-    --sync-mode full
+    --sync-mode full \
+    --logs-dir $DATADIR/logs \
+    --logs-rotation never

--- a/src/telemetry/logging.rs
+++ b/src/telemetry/logging.rs
@@ -16,6 +16,9 @@ use ansi_term::Colour::{Blue, Cyan, Purple, Red, Yellow};
 /// depending on the rotation strategy.
 const LOG_FILE_NAME_PREFIX: &'static str = "magi.log";
 
+/// Default log file rotation strategy. This can be overridden by the `logs_rotation` config.
+const DEFAULT_ROTATION: &'static str = "daily";
+
 /// Configure logging telemetry with a global handler.
 pub fn init(
     verbose: bool,
@@ -25,7 +28,7 @@ pub fn init(
     // If a directory is provided, log to file and stdout
     if let Some(dir) = logs_dir {
         let directory = PathBuf::from(dir);
-        let rotation = get_rotation_strategy(&logs_rotation.unwrap_or("never".into()));
+        let rotation = get_rotation_strategy(&logs_rotation.unwrap_or(DEFAULT_ROTATION.into()));
         let appender = Some(get_rolling_file_appender(
             directory,
             rotation,
@@ -202,7 +205,7 @@ where
 }
 
 /// Get the rotation strategy from the given string.
-/// Defaults to never rotating.
+/// Defaults to rotating daily.
 fn get_rotation_strategy(val: &str) -> Rotation {
     match val {
         "never" => Rotation::NEVER,
@@ -210,9 +213,9 @@ fn get_rotation_strategy(val: &str) -> Rotation {
         "hourly" => Rotation::HOURLY,
         "minutely" => Rotation::MINUTELY,
         _ => {
-            eprintln!("Invalid log rotation strategy provided. Defaulting to never rotating.");
+            eprintln!("Invalid log rotation strategy provided. Defaulting to rotating daily.");
             eprintln!("Valid rotation options are: 'never', 'daily', 'hourly', 'minutely'.");
-            Rotation::NEVER
+            Rotation::DAILY
         }
     }
 }

--- a/src/telemetry/logging.rs
+++ b/src/telemetry/logging.rs
@@ -1,39 +1,82 @@
-use std::env::current_dir;
-use std::path::Path;
+use std::{
+    env::current_dir,
+    path::{Path, PathBuf},
+};
 
-use eyre::Result;
-use tracing::subscriber::set_global_default;
-use tracing::{Level, Subscriber};
-use tracing_log::LogTracer;
-use tracing_subscriber::Layer;
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
+use tracing::Level;
+use tracing_appender::{
+    non_blocking::WorkerGuard,
+    rolling::{self, RollingFileAppender, Rotation},
+};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
 use ansi_term::Colour::{Blue, Cyan, Purple, Red, Yellow};
 
-/// Configure logging telemetry
-pub fn init(verbose: bool) -> Result<()> {
-    let subscriber = match verbose {
-        true => get_subscriber("magi=debug".into()),
-        false => get_subscriber("magi=info".into()),
-    };
-    init_subscriber(subscriber)
+/// Standard log file name prefix. This will be optionally appended with a timestamp
+/// depending on the rotation strategy.
+const LOG_FILE_NAME_PREFIX: &'static str = "magi.log";
+
+/// Configure logging telemetry with a global handler.
+pub fn init(
+    verbose: bool,
+    logs_dir: Option<String>,
+    logs_rotation: Option<String>,
+) -> Vec<WorkerGuard> {
+    // Only log to a file if a directory is provided
+    if let Some(dir) = logs_dir {
+        let directory = PathBuf::from(dir);
+        let rotation = get_rotation_strategy(&logs_rotation.unwrap_or("never".into()));
+        let appender = Some(get_rolling_file_appender(
+            directory,
+            rotation,
+            LOG_FILE_NAME_PREFIX,
+        ));
+        return build_subscriber(verbose, appender);
+    }
+
+    // If no directory is provided, log to stdout only
+    return build_subscriber(verbose, None);
 }
 
 /// Subscriber Composer
 ///
 /// Builds a subscriber with multiple layers into a [tracing](https://crates.io/crates/tracing) subscriber.
-pub fn get_subscriber(env_filter: String) -> impl Subscriber + Sync + Send {
-    let env_filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(env_filter));
-    let formatting_layer = AsniTermLayer;
-    Registry::default().with(env_filter).with(formatting_layer)
-}
+/// If an appender is provided, the subscriber will attach to it and log to the file as well as stdout.
+pub fn build_subscriber(verbose: bool, appender: Option<RollingFileAppender>) -> Vec<WorkerGuard> {
+    let mut guards = Vec::new();
 
-/// Globally registers a subscriber.
-/// This will error if a subscriber has already been registered.
-pub fn init_subscriber(subscriber: impl Subscriber + Send + Sync) -> Result<()> {
-    LogTracer::init().map_err(|_| eyre::eyre!("Failed to set logger"))?;
-    set_global_default(subscriber).map_err(|_| eyre::eyre!("Failed to set subscriber"))
+    let stdout_env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new(match verbose {
+            true => "magi=debug".to_owned(),
+            false => "magi=info".to_owned(),
+        })
+    });
+
+    let stdout_formatting_layer = AsniTermLayer.with_filter(stdout_env_filter);
+
+    if let Some(appender) = appender {
+        let (non_blocking, guard) = tracing_appender::non_blocking(appender);
+        guards.push(guard);
+
+        // Force the file logger to log at `debug` level
+        let file_env_filter = EnvFilter::from("magi=debug");
+
+        tracing_subscriber::registry()
+            .with(stdout_formatting_layer)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(non_blocking)
+                    .with_filter(file_env_filter),
+            )
+            .init();
+    } else {
+        tracing_subscriber::registry()
+            .with(stdout_formatting_layer)
+            .init();
+    }
+
+    guards
 }
 
 /// The AnsiVisitor
@@ -154,5 +197,35 @@ where
 
         let mut visitor = AnsiVisitor;
         event.record(&mut visitor);
+    }
+}
+
+/// Get the rotation strategy from the given string.
+/// Defaults to never rotating.
+fn get_rotation_strategy(val: &str) -> Rotation {
+    match val {
+        "never" => Rotation::NEVER,
+        "daily" => Rotation::DAILY,
+        "hourly" => Rotation::HOURLY,
+        "minutely" => Rotation::MINUTELY,
+        _ => {
+            eprintln!("Invalid log rotation strategy provided. Defaulting to never rotating.");
+            eprintln!("Valid rotation options are: 'never', 'daily', 'hourly', 'minutely'.");
+            Rotation::NEVER
+        }
+    }
+}
+
+/// Get a rolling file appender for the given directory, rotation and file name prefix.
+fn get_rolling_file_appender(
+    directory: PathBuf,
+    rotation: Rotation,
+    file_name_prefix: &str,
+) -> RollingFileAppender {
+    match rotation {
+        Rotation::NEVER => rolling::never(directory, file_name_prefix),
+        Rotation::DAILY => rolling::daily(directory, file_name_prefix),
+        Rotation::HOURLY => rolling::hourly(directory, file_name_prefix),
+        Rotation::MINUTELY => rolling::minutely(directory, file_name_prefix),
     }
 }

--- a/src/telemetry/logging.rs
+++ b/src/telemetry/logging.rs
@@ -22,7 +22,7 @@ pub fn init(
     logs_dir: Option<String>,
     logs_rotation: Option<String>,
 ) -> Vec<WorkerGuard> {
-    // Only log to a file if a directory is provided
+    // If a directory is provided, log to file and stdout
     if let Some(dir) = logs_dir {
         let directory = PathBuf::from(dir);
         let rotation = get_rotation_strategy(&logs_rotation.unwrap_or("never".into()));
@@ -40,8 +40,8 @@ pub fn init(
 
 /// Subscriber Composer
 ///
-/// Builds a subscriber with multiple layers into a [tracing](https://crates.io/crates/tracing) subscriber.
-/// If an appender is provided, the subscriber will attach to it and log to the file as well as stdout.
+/// Builds a subscriber with multiple layers into a [tracing](https://crates.io/crates/tracing) subscriber
+/// and initializes it as the global default. This subscriber will log to stdout and optionally to a file.
 pub fn build_subscriber(verbose: bool, appender: Option<RollingFileAppender>) -> Vec<WorkerGuard> {
     let mut guards = Vec::new();
 
@@ -54,6 +54,7 @@ pub fn build_subscriber(verbose: bool, appender: Option<RollingFileAppender>) ->
 
     let stdout_formatting_layer = AnsiTermLayer.with_filter(stdout_env_filter);
 
+    // If a file appender is provided, log to it and stdout, otherwise just log to stdout
     if let Some(appender) = appender {
         let (non_blocking, guard) = tracing_appender::non_blocking(appender);
         guards.push(guard);

--- a/src/telemetry/logging.rs
+++ b/src/telemetry/logging.rs
@@ -14,10 +14,10 @@ use ansi_term::Colour::{Blue, Cyan, Purple, Red, Yellow};
 
 /// Standard log file name prefix. This will be optionally appended with a timestamp
 /// depending on the rotation strategy.
-const LOG_FILE_NAME_PREFIX: &'static str = "magi.log";
+const LOG_FILE_NAME_PREFIX: &str = "magi.log";
 
 /// Default log file rotation strategy. This can be overridden by the `logs_rotation` config.
-const DEFAULT_ROTATION: &'static str = "daily";
+const DEFAULT_ROTATION: &str = "daily";
 
 /// Configure logging telemetry with a global handler.
 pub fn init(
@@ -38,7 +38,7 @@ pub fn init(
     }
 
     // If no directory is provided, log to stdout only
-    return build_subscriber(verbose, None);
+    build_subscriber(verbose, None)
 }
 
 /// Subscriber Composer

--- a/src/telemetry/logging.rs
+++ b/src/telemetry/logging.rs
@@ -52,7 +52,7 @@ pub fn build_subscriber(verbose: bool, appender: Option<RollingFileAppender>) ->
         })
     });
 
-    let stdout_formatting_layer = AsniTermLayer.with_filter(stdout_env_filter);
+    let stdout_formatting_layer = AnsiTermLayer.with_filter(stdout_env_filter);
 
     if let Some(appender) = appender {
         let (non_blocking, guard) = tracing_appender::non_blocking(appender);
@@ -119,9 +119,9 @@ impl tracing::field::Visit for AnsiVisitor {
 
 /// An Ansi Term layer for tracing
 #[derive(Debug)]
-pub struct AsniTermLayer;
+pub struct AnsiTermLayer;
 
-impl<S> Layer<S> for AsniTermLayer
+impl<S> Layer<S> for AnsiTermLayer
 where
     S: tracing::Subscriber,
 {


### PR DESCRIPTION
Added the ability to configure logging to a directory. 

Closes #85 

---

The implementation uses `tracing-appender` which plays quite well with the current tracing setup and provides a non-blocking subscriber for writing to files.

Features:

- new `cli.logs_dir` field to specify where to place logs. If `None` is provided, logging will only be done on stdout.
- new `cli.logs_rotation` field can also be specified to rotate log files every time period. If `None` is provided, the rotation policy is set to `never`.

I updated Magi's startup script with the new CLI fields, however I am not 100% sure of the locations specified for logs. Is `$DATADIR/logs` going to be fine?