### PR TITLE
feat(rpc): add rpc call to query output at block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,15 +75,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
-name = "async-lock"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,12 +1109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,24 +1520,9 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.8",
+ "rustls",
  "tokio",
- "tokio-rustls 0.23.4",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
-dependencies = [
- "http",
- "hyper",
- "log",
- "rustls 0.21.0",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls 0.24.0",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1721,32 +1691,10 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e7d80c64759234b8f4f134be632f8257ddcbfbba62bb35b43294a2a9773c54"
 dependencies = [
- "jsonrpsee-client-transport",
  "jsonrpsee-core",
- "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
- "jsonrpsee-ws-client",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b7f2bdccbd8c52cffd11950cdcee3a55ce9c1ecea991f9f766245c2ba115e1"
-dependencies = [
- "futures-util",
- "http",
- "jsonrpsee-core",
- "pin-project",
- "rustls-native-certs",
- "soketto",
- "thiserror",
- "tokio",
- "tokio-rustls 0.24.0",
- "tokio-util",
  "tracing",
 ]
 
@@ -1757,10 +1705,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900104d998256fd50af009da7a496d630588f615435880b1e5da19caf8627164"
 dependencies = [
  "anyhow",
- "async-lock",
  "async-trait",
  "beef",
- "futures-timer",
  "futures-util",
  "globset",
  "hyper",
@@ -1773,26 +1719,6 @@ dependencies = [
  "soketto",
  "thiserror",
  "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d65ba7e335248fad78768f4f73886b006784376bf05fa476520d41199457f04"
-dependencies = [
- "async-trait",
- "hyper",
- "hyper-rustls 0.24.0",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tower",
  "tracing",
 ]
 
@@ -1841,18 +1767,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d07b75527195638cad8942923241bbb375c68307eb3ef287e60db289f87824"
-dependencies = [
- "http",
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
 ]
 
 [[package]]
@@ -2631,7 +2545,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls 0.23.2",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2641,14 +2555,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.8",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2768,46 +2682,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki",
- "sct",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pemfile"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -3402,19 +3282,9 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.8",
+ "rustls",
  "tokio",
  "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
-dependencies = [
- "rustls 0.21.0",
- "tokio",
 ]
 
 [[package]]
@@ -3475,10 +3345,6 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "async-lock"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
+]
+
+[[package]]
+>>>>>>> 6649dcf (rpc server added)
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +290,15 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -288,6 +320,16 @@ name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
+name = "bstr"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -694,6 +736,15 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
@@ -1081,6 +1132,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,6 +1378,19 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -1665,10 +1735,32 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e7d80c64759234b8f4f134be632f8257ddcbfbba62bb35b43294a2a9773c54"
 dependencies = [
+ "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
+ "jsonrpsee-server",
  "jsonrpsee-types",
+ "jsonrpsee-ws-client",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b7f2bdccbd8c52cffd11950cdcee3a55ce9c1ecea991f9f766245c2ba115e1"
+dependencies = [
+ "futures-util",
+ "http",
+ "jsonrpsee-core",
+ "pin-project",
+ "rustls-native-certs",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.24.0",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1679,15 +1771,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900104d998256fd50af009da7a496d630588f615435880b1e5da19caf8627164"
 dependencies = [
  "anyhow",
+ "async-lock",
  "async-trait",
  "beef",
+ "futures-timer",
  "futures-util",
+ "globset",
  "hyper",
  "jsonrpsee-types",
+ "parking_lot 0.12.1",
+ "rand",
+ "rustc-hash",
  "serde",
  "serde_json",
+ "soketto",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
@@ -1724,6 +1824,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-server"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175b4db179fff94e56e314d6521158e9fbe1c714786dc7a237c7692bbebbc68c"
+dependencies = [
+ "futures-util",
+ "hyper",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "soketto",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "jsonrpsee-types"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1855,18 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49d07b75527195638cad8942923241bbb375c68307eb3ef287e60db289f87824"
+dependencies = [
+ "http",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -1996,6 +2128,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open-fastrlp"
@@ -2597,6 +2735,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2883,6 +3027,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2891,7 +3048,7 @@ dependencies = [
  "block-buffer 0.7.3",
  "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -2978,6 +3135,22 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "soketto"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "futures",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha-1",
 ]
 
 [[package]]
@@ -3259,6 +3432,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,6 +3450,7 @@ checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +197,15 @@ name = "bech32"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -1464,9 +1479,24 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls 0.21.0",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.24.0",
 ]
 
 [[package]]
@@ -1630,6 +1660,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e7d80c64759234b8f4f134be632f8257ddcbfbba62bb35b43294a2a9773c54"
+dependencies = [
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900104d998256fd50af009da7a496d630588f615435880b1e5da19caf8627164"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "beef",
+ "futures-util",
+ "hyper",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d65ba7e335248fad78768f4f73886b006784376bf05fa476520d41199457f04"
+dependencies = [
+ "async-trait",
+ "hyper",
+ "hyper-rustls 0.24.0",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5972c84d14d6280f46dca3abc4ca8487e080a533f8a9f286c4443bed28f9fe"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c79398a1b916c20ea911eb8fb86488709e6c078b64dbf2d1a9cec14c1677605"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +1854,7 @@ dependencies = [
  "eyre",
  "figment",
  "hex",
+ "jsonrpsee",
  "jsonwebtoken",
  "lazy_static",
  "libflate",
@@ -2398,7 +2507,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2408,14 +2517,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2529,12 +2638,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3100,9 +3243,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.0",
+ "tokio",
 ]
 
 [[package]]
@@ -3146,6 +3299,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,6 +3332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,8 +75,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
-<<<<<<< HEAD
-=======
 name = "async-lock"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,18 +84,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.12",
-]
-
-[[package]]
->>>>>>> 6649dcf (rpc server added)
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4.3"
 libflate = "1.2.0"
 openssl = { version = "0.10", features = ["vendored"] }
 once_cell = "1"
-jsonrpsee = {version = "0.17.0", features = ["http-client", "macros"]}
+jsonrpsee = {version = "0.17.0", features = ["server", "http-client", "ws-client", "macros", "client-ws-transport-native-tls"]}
 
 # Logging and Metrics
 chrono = "0.4.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ hex = "0.4.3"
 libflate = "1.2.0"
 openssl = { version = "0.10", features = ["vendored"] }
 once_cell = "1"
+jsonrpsee = {version = "0.17.0", features = ["http-client", "macros"]}
 
 # Logging and Metrics
 chrono = "0.4.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4.3"
 libflate = "1.2.0"
 openssl = { version = "0.10", features = ["vendored"] }
 once_cell = "1"
-jsonrpsee = {version = "0.17.0", features = ["server", "http-client", "ws-client", "macros", "client-ws-transport-native-tls"]}
+jsonrpsee = {version = "0.17.0", features = ["server", "macros"]}
 
 # Logging and Metrics
 chrono = "0.4.22"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - .env
     ports:
       - 9200:9200
+      - 9545:9545
     volumes:
       - ./:/scripts
       - data:/data
@@ -60,14 +61,9 @@ services:
     env_file:
       - .env
     ports:
-<<<<<<< HEAD
       - 8551:8551
       - 8545:8545
       - 8546:8546
-=======
-      - 9200:9200
-      - 9545:9545
->>>>>>> 79c33b8 (rpc server added)
     volumes:
       - ./:/scripts
       - data:/data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,9 +60,14 @@ services:
     env_file:
       - .env
     ports:
+<<<<<<< HEAD
       - 8551:8551
       - 8545:8545
       - 8546:8546
+=======
+      - 9200:9200
+      - 9545:9545
+>>>>>>> 79c33b8 (rpc server added)
     volumes:
       - ./:/scripts
       - data:/data

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -244,7 +244,7 @@ impl ChainConfig {
             system_config_contract: addr("0xb15eea247ece011c68a614e4a77ad648ff495bc1"),
             batch_inbox: addr("0x8453100000000000000000000000000000000000"),
             deposit_contract: addr("0xe93c8cd0d409341205a592f8c4ac1a5fe5585cfa"),
-            l2_to_l1_message_parser_address: addr("0xEF2ec5A5465f075E010BE70966a8667c94BCe15a"), // TODO(madhur): fix this
+            l2_to_l1_message_parser_address: addr("0x4200000000000000000000000000000000000016"),
             max_channel_size: 100_000_000,
             channel_timeout: 100,
             seq_window_size: 3600,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -125,6 +125,8 @@ pub struct ChainConfig {
     /// Network blocktime
     #[serde(default = "default_blocktime")]
     pub blocktime: u64,
+    /// L2 To L1 Message parser address
+    pub l2_to_l1_message_parser_address: Address,
 }
 
 /// Optimism system config contract values
@@ -210,6 +212,7 @@ impl ChainConfig {
             system_config_contract: addr("0xAe851f927Ee40dE99aaBb7461C00f9622ab91d60"),
             batch_inbox: addr("0xff00000000000000000000000000000000000420"),
             deposit_contract: addr("0x5b47E1A08Ea6d985D6649300584e6722Ec4B1383"),
+            l2_to_l1_message_parser_address: addr("0xEF2ec5A5465f075E010BE70966a8667c94BCe15a"),
             max_channel_size: 100_000_000,
             channel_timeout: 300,
             seq_window_size: 3600,
@@ -241,6 +244,7 @@ impl ChainConfig {
             system_config_contract: addr("0xb15eea247ece011c68a614e4a77ad648ff495bc1"),
             batch_inbox: addr("0x8453100000000000000000000000000000000000"),
             deposit_contract: addr("0xe93c8cd0d409341205a592f8c4ac1a5fe5585cfa"),
+            l2_to_l1_message_parser_address: addr("0xEF2ec5A5465f075E010BE70966a8667c94BCe15a"), // TODO(madhur): fix this
             max_channel_size: 100_000_000,
             channel_timeout: 100,
             seq_window_size: 3600,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -125,8 +125,8 @@ pub struct ChainConfig {
     /// Network blocktime
     #[serde(default = "default_blocktime")]
     pub blocktime: u64,
-    /// L2 To L1 Message parser address
-    pub l2_to_l1_message_parser_address: Address,
+    /// L2 To L1 Message passer address
+    pub l2_to_l1_message_passer: Address,
 }
 
 /// Optimism system config contract values
@@ -212,7 +212,7 @@ impl ChainConfig {
             system_config_contract: addr("0xAe851f927Ee40dE99aaBb7461C00f9622ab91d60"),
             batch_inbox: addr("0xff00000000000000000000000000000000000420"),
             deposit_contract: addr("0x5b47E1A08Ea6d985D6649300584e6722Ec4B1383"),
-            l2_to_l1_message_parser_address: addr("0xEF2ec5A5465f075E010BE70966a8667c94BCe15a"),
+            l2_to_l1_message_passer: addr("0xEF2ec5A5465f075E010BE70966a8667c94BCe15a"),
             max_channel_size: 100_000_000,
             channel_timeout: 300,
             seq_window_size: 3600,
@@ -244,7 +244,7 @@ impl ChainConfig {
             system_config_contract: addr("0xb15eea247ece011c68a614e4a77ad648ff495bc1"),
             batch_inbox: addr("0x8453100000000000000000000000000000000000"),
             deposit_contract: addr("0xe93c8cd0d409341205a592f8c4ac1a5fe5585cfa"),
-            l2_to_l1_message_parser_address: addr("0x4200000000000000000000000000000000000016"),
+            l2_to_l1_message_passer: addr("0x4200000000000000000000000000000000000016"),
             max_channel_size: 100_000_000,
             channel_timeout: 100,
             seq_window_size: 3600,

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -86,7 +86,7 @@ impl Driver<EngineApi> {
         let pipeline = Pipeline::new(state.clone(), config)?;
 
         let config_arc = Arc::new(config_clone);
-        let _addr = rpc::run_server(config_arc);
+        let _addr = rpc::run_server(config_arc).await?;
 
         Ok(Self {
             engine_driver,

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     driver::types::HeadInfo,
     engine::{Engine, EngineApi},
     l1::{BlockUpdate, ChainWatcher},
-    rpc::Rpc,
+    rpc,
     telemetry::metrics,
 };
 
@@ -44,8 +44,6 @@ pub struct Driver<E: Engine> {
     chain_watcher: ChainWatcher,
     /// Channel to receive the shutdown signal from
     shutdown_recv: Receiver<bool>,
-    /// Rpc client to talk to L2 rpc
-    rpc: Rpc,
 }
 
 impl Driver<EngineApi> {
@@ -88,7 +86,7 @@ impl Driver<EngineApi> {
         let pipeline = Pipeline::new(state.clone(), config)?;
 
         let config_arc = Arc::new(config_clone);
-        let rpc = Rpc::new(&config_arc).unwrap();
+        let _addr = rpc::run_server(config_arc);
 
         Ok(Self {
             engine_driver,
@@ -98,7 +96,6 @@ impl Driver<EngineApi> {
             state,
             chain_watcher,
             shutdown_recv,
-            rpc,
         })
     }
 }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -68,7 +68,6 @@ impl Driver<EngineApi> {
 
         tracing::info!("syncing from: {:?}", finalized_head.hash);
 
-        let config_clone = config.clone();
         let config = Arc::new(config);
         let chain_watcher = ChainWatcher::new(
             finalized_epoch.number,
@@ -83,10 +82,9 @@ impl Driver<EngineApi> {
         )));
 
         let engine_driver = EngineDriver::new(finalized_head, finalized_epoch, provider, &config)?;
-        let pipeline = Pipeline::new(state.clone(), config)?;
+        let pipeline = Pipeline::new(state.clone(), config.clone())?;
 
-        let config_arc = Arc::new(config_clone);
-        let _addr = rpc::run_server(config_arc).await?;
+        let _addr = rpc::run_server(config).await?;
 
         Ok(Self {
             engine_driver,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,5 +19,5 @@ pub mod engine;
 /// Application telemetry and logging
 pub mod telemetry;
 
-/// RPC module to talk to rpc direcly
+/// RPC module to host rpc server
 pub mod rpc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,6 @@ pub mod engine;
 
 /// Application telemetry and logging
 pub mod telemetry;
+
+/// RPC module to talk to rpc direcly
+pub mod rpc;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,9 +1,8 @@
-use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::config::Config;
 
-use ethers::types::{Block, BlockId, H160, H256};
+use ethers::types::{Block, BlockId, H256};
 
 use eyre::Result;
 
@@ -39,13 +38,11 @@ impl RpcServer for RpcServerImpl {
 
         let state_root = block.state_root;
         let block_hash = block.hash.unwrap();
-        let locations = vec![state_root];
+        let locations = vec![];
         let block_id = Some(BlockId::from(block_hash));
 
-        // TODO hange this
-        let from = H160::from_str("0x4200000000000000000000000000000000000016").unwrap();
         let state_proof = l2_provider
-            .get_proof(from, locations, block_id)
+            .get_proof(self.config.chain.l2_to_l1_message_parser_address, locations, block_id)
             .await
             .unwrap();
 

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -6,40 +6,55 @@ use ethers::types::H256;
 
 use eyre::Result;
 
+use ethers::providers::{Middleware, Provider};
+
 use jsonrpsee::{
-    core::client::ClientT,
-    http_client::{transport::HttpBackend, HttpClientBuilder},
-    rpc_params,
+    core::{async_trait, Error},
+    proc_macros::rpc,
+    server::ServerBuilder,
 };
 use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
 
-pub struct Rpc {
-    l2_rpc: jsonrpsee::http_client::HttpClient<HttpBackend>,
+#[rpc(server, client, namespace = "rpc")]
+pub trait Rpc {
+    #[method(name = "optimism_outputAtBlock")]
+    async fn optimism_output_at_block(&self, block_number: u64) -> Result<H256, Error>;
+}
+
+#[derive(Debug)]
+pub struct RpcServerImpl {
+    config: Arc<Config>,
+}
+
+#[async_trait]
+impl RpcServer for RpcServerImpl {
+    async fn optimism_output_at_block(&self, block_number: u64) -> Result<H256, Error> {
+        let l2_provider =
+            Provider::try_from(self.config.l2_rpc_url.clone()).expect("invalid L2 RPC url");
+        let block = l2_provider.get_block(block_number).await.unwrap().unwrap();
+
+        // let output_response: OutputRootResponse = serde_json::from_value(response)?;
+
+        Ok(block.state_root)
+    }
+}
+
+pub async fn run_server(config: Arc<Config>) -> Result<SocketAddr> {
+    let server = ServerBuilder::default().build("127.0.0.1:9545").await?;
+    let addr = server.local_addr()?;
+    let rpc_impl = RpcServerImpl { config };
+    let handle = server.start(rpc_impl.into_rpc())?;
+
+    // In this example we don't care about doing shutdown so let's it run forever.
+    // You may use the `ServerHandle` to shut it down or manage it yourself.
+    tokio::spawn(handle.stopped());
+
+    Ok(addr)
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct OutputRootResponse {
     pub l2_root_output: H256,
     pub version: H256,
-}
-
-impl Rpc {
-    pub fn new(config: &Arc<Config>) -> Result<Self> {
-        let l2_rpc = HttpClientBuilder::default()
-            .build(config.l2_rpc_url.clone())
-            .unwrap();
-
-        Ok(Self { l2_rpc })
-    }
-
-    pub async fn get_output_root_at_block(&self, block_number: u64) -> Result<H256> {
-        let params = rpc_params![block_number];
-        let response = self
-            .l2_rpc
-            .request("optimism_outputAtBlock", params)
-            .await?;
-        let output_response: OutputRootResponse = serde_json::from_value(response)?;
-
-        Ok(output_response.l2_root_output)
-    }
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -16,7 +16,7 @@ use jsonrpsee::{
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
-#[rpc(server, client, namespace = "rpc")]
+#[rpc(server, client)]
 pub trait Rpc {
     #[method(name = "optimism_outputAtBlock")]
     async fn optimism_output_at_block(&self, block_number: u64) -> Result<H256, Error>;
@@ -49,6 +49,7 @@ pub async fn run_server(config: Arc<Config>) -> Result<SocketAddr> {
     // In this example we don't care about doing shutdown so let's it run forever.
     // You may use the `ServerHandle` to shut it down or manage it yourself.
     tokio::spawn(handle.stopped());
+    tracing::info!("rpc server started at port 9545");
 
     Ok(addr)
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+
+use crate::config::Config;
+
+use ethers::types::H256;
+
+use eyre::Result;
+
+use jsonrpsee::{
+    core::client::ClientT,
+    http_client::{transport::HttpBackend, HttpClientBuilder},
+    rpc_params,
+};
+use serde::{Deserialize, Serialize};
+
+pub struct Rpc {
+    l2_rpc: jsonrpsee::http_client::HttpClient<HttpBackend>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct OutputRootResponse {
+    pub l2_root_output: H256,
+    pub version: H256,
+}
+
+impl Rpc {
+    pub fn new(config: &Arc<Config>) -> Result<Self> {
+        let l2_rpc = HttpClientBuilder::default()
+            .build(config.l2_rpc_url.clone())
+            .unwrap();
+
+        Ok(Self { l2_rpc })
+    }
+
+    pub async fn get_output_root_at_block(&self, block_number: u64) -> Result<H256> {
+        let params = rpc_params![block_number];
+        let response = self
+            .l2_rpc
+            .request("optimism_outputAtBlock", params)
+            .await?;
+        let output_response: OutputRootResponse = serde_json::from_value(response)?;
+
+        Ok(output_response.l2_root_output)
+    }
+}


### PR DESCRIPTION
- Added RPC to get latest output root at block


TODO

- [x] RPC Server
- [x] Return actual output root 
- [x] Clarify `from` address and inputs to `get_proof`
- [x] How to run and test the endpoint

### Sample request/response
Request
```
{
    "jsonrpc": "2.0",
    "method": "optimism_outputAtBlock",
    "params": [4074155],
    "id": 1
}
```

Response
```
{
    "jsonrpc": "2.0",
    "result": {
        "outputRoot": "0xd644fd2ec6bd24785902a47f16b243af1a08db9c8fd8d148278b7177712858e6",
        "version": "0x0000000000000000000000000000000000000000000000000000000000000000",
        "stateRoot": "0x762473ad22b64cd68f4704b2af32b88ca32b81b324713ef6773556ff8bb4674e",
        "withdrawalStorageRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
    },
    "id": 1
}
```

Error handling, unit tests coming in subsequent PR.

Fixes #86 