### PR TITLE
perf(l1): avoid event topic rehashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,6 +1795,7 @@ dependencies = [
  "jsonwebtoken",
  "lazy_static",
  "libflate",
+ "once_cell",
  "openssl",
  "prometheus_exporter",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ ethers= "1.0.2"
 hex = "0.4.3"
 libflate = "1.2.0"
 openssl = { version = "0.10", features = ["vendored"] }
+once_cell = "1"
 
 # Logging and Metrics
 chrono = "0.4.22"

--- a/src/l1/mod.rs
+++ b/src/l1/mod.rs
@@ -18,6 +18,7 @@ use ethers::{
 };
 
 use eyre::Result;
+use once_cell::sync::Lazy;
 use tokio::{spawn, task::JoinHandle, time::sleep};
 
 use crate::{
@@ -170,6 +171,14 @@ impl ChainWatcher {
 }
 
 impl InnerWatcher {
+    const CONFIG_UPDATE_TOPIC: Lazy<H256> =
+        Lazy::new(|| H256::from_slice(&keccak256("ConfigUpdate(uint256,uint8,bytes)")));
+    const TRANSACTION_DEPOSITED_TOPIC: Lazy<H256> = Lazy::new(|| {
+        H256::from_slice(&keccak256(
+            "TransactionDeposited(address,address,uint256,bytes)",
+        ))
+    });
+
     async fn new(
         config: Arc<Config>,
         block_update_sender: SyncSender<BlockUpdate>,
@@ -284,11 +293,9 @@ impl InnerWatcher {
 
         if last_update_block < self.current_block {
             let to_block = last_update_block + 1000;
-            let update_event = "ConfigUpdate(uint256,uint8,bytes)";
-            let update_topic = H256::from_slice(&keccak256(update_event));
             let filter = Filter::new()
                 .address(self.config.chain.system_config_contract)
-                .topic0(update_topic)
+                .topic0(*Self::CONFIG_UPDATE_TOPIC)
                 .from_block(last_update_block + 1)
                 .to_block(to_block);
 
@@ -376,14 +383,11 @@ impl InnerWatcher {
         match self.deposits.remove(&block_num) {
             Some(deposits) => Ok(deposits),
             None => {
-                let deposit_event = "TransactionDeposited(address,address,uint256,bytes)";
-                let deposit_topic = H256::from_slice(&keccak256(deposit_event));
-
                 let end_block = self.head_block.min(block_num + 1000);
 
                 let deposit_filter = Filter::new()
                     .address(self.config.chain.deposit_contract)
-                    .topic0(deposit_topic)
+                    .topic0(*Self::TRANSACTION_DEPOSITED_TOPIC)
                     .from_block(block_num)
                     .to_block(end_block);
 


### PR DESCRIPTION
Avoid rehashing of event signatures in the chain watcher.

Used `once_cell` instead of existing `lazy_static` dep, because it's [making its way to std](https://github.com/rust-lang/rust/pull/105587). Happy to swap existing static metrics to `once_cell` as well in a follow-up PR, when this one is merged.