### PR TITLE
fix: forkchoice update race condition

### DIFF
--- a/src/driver/engine_driver.rs
+++ b/src/driver/engine_driver.rs
@@ -38,7 +38,7 @@ impl<E: Engine> EngineDriver<E> {
 
         if let Some(block) = block {
             if should_skip(&block, &attributes)? {
-                self.skip_attributes(attributes, block)
+                self.skip_attributes(attributes, block).await
             } else {
                 self.unsafe_head = self.safe_head;
                 self.process_attributes(attributes).await
@@ -100,10 +100,11 @@ impl<E: Engine> EngineDriver<E> {
         Ok(())
     }
 
-    fn skip_attributes(&mut self, attributes: PayloadAttributes, block: Block<H256>) -> Result<()> {
+    async fn skip_attributes(&mut self, attributes: PayloadAttributes, block: Block<H256>) -> Result<()> {
         let new_epoch = *attributes.epoch.as_ref().unwrap();
         let new_head = BlockInfo::try_from(block)?;
         self.update_safe_head(new_head, new_epoch, false)?;
+        self.update_forkchoice().await?;
 
         Ok(())
     }

--- a/src/driver/engine_driver.rs
+++ b/src/driver/engine_driver.rs
@@ -100,7 +100,11 @@ impl<E: Engine> EngineDriver<E> {
         Ok(())
     }
 
-    async fn skip_attributes(&mut self, attributes: PayloadAttributes, block: Block<H256>) -> Result<()> {
+    async fn skip_attributes(
+        &mut self,
+        attributes: PayloadAttributes,
+        block: Block<H256>,
+    ) -> Result<()> {
         let new_epoch = *attributes.epoch.as_ref().unwrap();
         let new_head = BlockInfo::try_from(block)?;
         self.update_safe_head(new_head, new_epoch, false)?;


### PR DESCRIPTION
Using tokio spawn for the forkchoice update meant that it was possible to attempt to build the next payload before the forkchoice update took effect on the execution engine. If this happens for an unsafe block, when we try to apply the same block as a safe block, we will end up not skipping that update, and attempt to build a payload on the wrong parent which will fail.