### PR TITLE
feat: support startup on non epoch boundary

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,9 +1,9 @@
 use std::fmt::Debug;
 
 use ethers::{
-    abi::{parse_abi_str, FixedBytes},
+    abi::parse_abi_str,
     prelude::BaseContract,
-    types::{Block, Bytes, H256, U256},
+    types::{Block, Bytes, Transaction, H256, U256},
     utils::rlp::{Decodable, DecoderError, Rlp},
 };
 use eyre::Result;
@@ -47,10 +47,10 @@ impl From<BlockInfo> for Value {
     }
 }
 
-impl<T> TryFrom<Block<T>> for BlockInfo {
+impl TryFrom<Block<Transaction>> for BlockInfo {
     type Error = eyre::Report;
 
-    fn try_from(block: Block<T>) -> Result<Self> {
+    fn try_from(block: Block<Transaction>) -> Result<Self> {
         let number = block
             .number
             .ok_or(eyre::eyre!("block not included"))?
@@ -88,28 +88,59 @@ impl From<&ExecutionPayload> for BlockInfo {
     }
 }
 
-type SetL1BlockValueInput = (u64, u64, U256, FixedBytes, u64, FixedBytes, U256, U256);
+pub struct AttributesDepositedCall {
+    pub number: u64,
+    pub timestamp: u64,
+    pub basefee: U256,
+    pub hash: H256,
+    pub sequence_number: u64,
+    pub batcher_hash: H256,
+    pub fee_overhead: U256,
+    pub fee_scalar: U256,
+}
 
-/// Minimal L1Block ABI from the contract [implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/L2/L1Block.sol).
+type SetL1BlockValueInput = (u64, u64, U256, H256, u64, H256, U256, U256);
 const L1_BLOCK_CONTRACT_ABI: &str = r#"[
-                function setL1BlockValues(uint64 _number,uint64 _timestamp, uint256 _basefee, bytes32 _hash,uint64 _sequenceNumber,bytes32 _batcherHash,uint256 _l1FeeOverhead,uint256 _l1FeeScalar) external
-            ]"#;
+    function setL1BlockValues(uint64 _number,uint64 _timestamp, uint256 _basefee, bytes32 _hash,uint64 _sequenceNumber,bytes32 _batcherHash,uint256 _l1FeeOverhead,uint256 _l1FeeScalar) external
+]"#;
 
-impl TryFrom<Bytes> for Epoch {
+impl TryFrom<Bytes> for AttributesDepositedCall {
     type Error = eyre::Report;
 
-    /// Performs the conversion from the `setL1BlockValues` calldata to [Epoch].
-    fn try_from(tx_calldata: Bytes) -> Result<Self> {
+    fn try_from(value: Bytes) -> Result<Self> {
         let abi = BaseContract::from(parse_abi_str(L1_BLOCK_CONTRACT_ABI)?);
 
-        let (number, timestamp, _, hash, ..): SetL1BlockValueInput =
-            abi.decode("setL1BlockValues", tx_calldata)?;
+        let (
+            number,
+            timestamp,
+            basefee,
+            hash,
+            sequence_number,
+            batcher_hash,
+            fee_overhead,
+            fee_scalar,
+        ): SetL1BlockValueInput = abi.decode("setL1BlockValues", value)?;
 
         Ok(Self {
             number,
             timestamp,
-            hash: H256::from_slice(&hash),
+            basefee,
+            hash,
+            sequence_number,
+            batcher_hash,
+            fee_overhead,
+            fee_scalar,
         })
+    }
+}
+
+impl From<&AttributesDepositedCall> for Epoch {
+    fn from(call: &AttributesDepositedCall) -> Self {
+        Self {
+            number: call.number,
+            timestamp: call.timestamp,
+            hash: call.hash,
+        }
     }
 }
 
@@ -142,16 +173,15 @@ impl<'de> Deserialize<'de> for RawTransaction {
 
 #[cfg(test)]
 mod tests {
-
-    mod epoch {
+    mod attributed_deposited_call {
         use std::str::FromStr;
 
         use ethers::types::{Bytes, H256};
 
-        use crate::common::Epoch;
+        use crate::common::AttributesDepositedCall;
 
         #[test]
-        fn should_convert_from_the_deposited_transaction_calldata() -> eyre::Result<()> {
+        fn decode_from_bytes() -> eyre::Result<()> {
             // Arrange
             let calldata = "0x015d8eb900000000000000000000000000000000000000000000000000000000008768240000000000000000000000000000000000000000000000000000000064443450000000000000000000000000000000000000000000000000000000000000000e0444c991c5fe1d7291ff34b3f5c3b44ee861f021396d33ba3255b83df30e357d00000000000000000000000000000000000000000000000000000000000000050000000000000000000000007431310e026b69bfc676c0013e12a1a11411eec9000000000000000000000000000000000000000000000000000000000000083400000000000000000000000000000000000000000000000000000000000f4240";
 
@@ -161,15 +191,15 @@ mod tests {
             let expected_timestamp = 1682191440;
 
             // Act
-            let epoch = Epoch::try_from(Bytes::from_str(calldata)?);
+            let call = AttributesDepositedCall::try_from(Bytes::from_str(calldata)?);
 
             // Assert
-            assert!(epoch.is_ok());
-            let epoch = epoch.unwrap();
+            assert!(call.is_ok());
+            let call = call.unwrap();
 
-            assert_eq!(epoch.hash, expected_hash);
-            assert_eq!(epoch.number, expected_block_number);
-            assert_eq!(epoch.timestamp, expected_timestamp);
+            assert_eq!(call.hash, expected_hash);
+            assert_eq!(call.number, expected_block_number);
+            assert_eq!(call.timestamp, expected_timestamp);
 
             Ok(())
         }

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -39,12 +39,12 @@ impl Iterator for Pipeline {
 }
 
 impl Pipeline {
-    pub fn new(state: Arc<RwLock<State>>, config: Arc<Config>) -> Result<Self> {
+    pub fn new(state: Arc<RwLock<State>>, config: Arc<Config>, seq: u64) -> Result<Self> {
         let (tx, rx) = mpsc::channel();
         let batcher_transactions = BatcherTransactions::new(rx);
         let channels = Channels::new(batcher_transactions, config.clone());
         let batches = Batches::new(channels, state.clone(), config.clone());
-        let attributes = Attributes::new(Box::new(batches), state, config);
+        let attributes = Attributes::new(Box::new(batches), state, config, seq);
 
         Ok(Self {
             batcher_transaction_sender: tx,
@@ -125,7 +125,7 @@ mod tests {
                 config.clone(),
             )));
 
-            let mut pipeline = Pipeline::new(state.clone(), config.clone()).unwrap();
+            let mut pipeline = Pipeline::new(state.clone(), config.clone(), 0).unwrap();
 
             chain_watcher.block_update_receiver.recv().unwrap();
             let update = chain_watcher.block_update_receiver.recv().unwrap();

--- a/src/derive/stages/attributes.rs
+++ b/src/derive/stages/attributes.rs
@@ -46,13 +46,14 @@ impl Attributes {
         batch_iter: Box<dyn PurgeableIterator<Item = Batch>>,
         state: Arc<RwLock<State>>,
         config: Arc<Config>,
+        seq: u64,
     ) -> Self {
         let epoch_hash = state.read().unwrap().safe_epoch.hash;
 
         Self {
             batch_iter,
             state,
-            sequence_number: 0,
+            sequence_number: seq,
             epoch_hash,
             config,
         }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -65,11 +65,13 @@ impl Driver<EngineApi> {
                 HeadInfo {
                     l2_block_info: config.chain.l2_genesis,
                     l1_epoch: config.chain.l1_start_epoch,
+                    sequence_number: 0,
                 }
             });
 
         let finalized_head = head.l2_block_info;
         let finalized_epoch = head.l1_epoch;
+        let finalized_seq = head.sequence_number;
 
         tracing::info!("starting from head: {:?}", finalized_head.hash);
 
@@ -87,7 +89,7 @@ impl Driver<EngineApi> {
         )));
 
         let engine_driver = EngineDriver::new(finalized_head, finalized_epoch, provider, &config)?;
-        let pipeline = Pipeline::new(state.clone(), config.clone())?;
+        let pipeline = Pipeline::new(state.clone(), config.clone(), finalized_seq)?;
 
         let _addr = rpc::run_server(config.clone()).await?;
 


### PR DESCRIPTION
This is useful when a datadir (such as the one that op-erigon team ships) is snapshotted not on an epoch boundary. This will also let us finalize blocks that are not on an epoch boundary with only a few more modifications. Will address that in a follow up PR.