### PR TITLE
feat: use official op-erigon snapshot

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     <<: *logging
 
   op-erigon:
-    image: testinprod/op-erigon
+    image: testinprod/op-erigon:latest
     container_name: op-erigon
     profiles:
       - op-erigon

--- a/docker/start-op-erigon.sh
+++ b/docker/start-op-erigon.sh
@@ -9,7 +9,7 @@ then
     then
         # apk update && apk install tar
         mkdir $DATADIR
-        wget "https://op-erigon-genesis.s3.amazonaws.com/erigon.tar.gz" -O erigon.tar.gz
+        wget "https://backup.goerli.op-erigon.testinprod.io" -O erigon.tar.gz
         tar -zxvf erigon.tar.gz -C /tmp
         mv /tmp/chaindata $DATADIR
     fi


### PR DESCRIPTION
Now that we have merged #139, we can use the official op-erigon snapshots which were not guaranteed to be on an epoch boundary