### PR TITLE
Feat/add support for external chains via JSON

### DIFF
--- a/bin/magi.rs
+++ b/bin/magi.rs
@@ -70,7 +70,12 @@ impl Cli {
             "optimism" => ChainConfig::optimism(),
             "optimism-goerli" => ChainConfig::optimism_goerli(),
             "base-goerli" => ChainConfig::base_goerli(),
-            _ => panic!("network not recognized"),
+            file if file.ends_with(".json") => ChainConfig::from_json(file),
+            _ => panic!(
+                "Invalid network name. \\
+                Please use one of the following: 'optimism', 'optimism-goerli', 'base-goerli'. \\
+                You can also use a JSON file path for custom configuration."
+            ),
         };
 
         let config_path = home_dir().unwrap().join(".magi/magi.toml");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -111,8 +111,10 @@ pub struct CliConfig {
 pub struct ChainConfig {
     /// The network name
     pub network: String,
-    /// The chain id
-    pub chain_id: u64,
+    /// The L1 chain id
+    pub l1_chain_id: u64,
+    /// The L2 chain id
+    pub l2_chain_id: u64,
     /// The L1 block referenced by the L2 chain
     pub l1_start_epoch: Epoch,
     /// The L2 genesis block info
@@ -154,7 +156,7 @@ pub struct SystemConfig {
     /// Fee scalar
     pub l1_fee_scalar: U256,
     /// Sequencer's signer for unsafe blocks
-    pub unsafe_block_singer: Address,
+    pub unsafe_block_signer: Address,
 }
 
 impl SystemConfig {
@@ -207,7 +209,8 @@ impl ChainConfig {
     pub fn optimism() -> Self {
         Self {
             network: "optimism".to_string(),
-            chain_id: 10,
+            l1_chain_id: 1,
+            l2_chain_id: 10,
             l1_start_epoch: Epoch {
                 hash: hash("0x438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"),
                 number: 17422590,
@@ -226,7 +229,7 @@ impl ChainConfig {
                 gas_limit: U256::from(30_000_000),
                 l1_fee_overhead: U256::from(188),
                 l1_fee_scalar: U256::from(684000),
-                unsafe_block_singer: addr("0xAAAA45d9549EDA09E70937013520214382Ffc4A2"),
+                unsafe_block_signer: addr("0xAAAA45d9549EDA09E70937013520214382Ffc4A2"),
             },
             batch_inbox: addr("0xff00000000000000000000000000000000000010"),
             deposit_contract: addr("0xbEb5Fc579115071764c7423A4f12eDde41f106Ed"),
@@ -243,7 +246,8 @@ impl ChainConfig {
     pub fn optimism_goerli() -> Self {
         Self {
             network: "optimism-goerli".to_string(),
-            chain_id: 420,
+            l1_chain_id: 5,
+            l2_chain_id: 420,
             l1_start_epoch: Epoch {
                 hash: hash("0x6ffc1bf3754c01f6bb9fe057c1578b87a8571ce2e9be5ca14bace6eccfd336c7"),
                 number: 8300214,
@@ -262,7 +266,7 @@ impl ChainConfig {
                 gas_limit: U256::from(25_000_000),
                 l1_fee_overhead: U256::from(2100),
                 l1_fee_scalar: U256::from(1000000),
-                unsafe_block_singer: addr("0x715b7219D986641DF9eFd9C7Ef01218D528e19ec"),
+                unsafe_block_signer: addr("0x715b7219D986641DF9eFd9C7Ef01218D528e19ec"),
             },
             system_config_contract: addr("0xAe851f927Ee40dE99aaBb7461C00f9622ab91d60"),
             batch_inbox: addr("0xff00000000000000000000000000000000000420"),
@@ -279,7 +283,8 @@ impl ChainConfig {
     pub fn base_goerli() -> Self {
         Self {
             network: "base-goerli".to_string(),
-            chain_id: 84531,
+            l1_chain_id: 5,
+            l2_chain_id: 84531,
             l1_start_epoch: Epoch {
                 number: 8410981,
                 hash: hash("0x73d89754a1e0387b89520d989d3be9c37c1f32495a88faf1ea05c61121ab0d19"),
@@ -296,7 +301,7 @@ impl ChainConfig {
                 gas_limit: U256::from(25_000_000),
                 l1_fee_overhead: U256::from(2100),
                 l1_fee_scalar: U256::from(1000000),
-                unsafe_block_singer: addr("0x32a4e99A72c11E9DD3dC159909a2D7BD86C1Bc51"),
+                unsafe_block_signer: addr("0x32a4e99A72c11E9DD3dC159909a2D7BD86C1Bc51"),
             },
             system_config_contract: addr("0xb15eea247ece011c68a614e4a77ad648ff495bc1"),
             batch_inbox: addr("0x8453100000000000000000000000000000000000"),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -206,6 +206,13 @@ impl Default for DefaultsProvider {
 }
 
 impl ChainConfig {
+    /// Read and parse a chain config object from a JSON file path
+    pub fn from_json(path: &str) -> Self {
+        let file = std::fs::File::open(path).unwrap();
+        let external: ExternalChainConfig = serde_json::from_reader(file).unwrap();
+        external.into()
+    }
+
     pub fn optimism() -> Self {
         Self {
             network: "optimism".to_string(),
@@ -419,13 +426,6 @@ impl From<ExternalChainConfig> for ChainConfig {
             l2_to_l1_message_passer: Address::zero(),
         }
     }
-}
-
-/// Read and parse a chain config object from a JSON file path
-pub fn read_chain_config_from_json(path: &str) -> ChainConfig {
-    let file = std::fs::File::open(path).unwrap();
-    let external: ExternalChainConfig = serde_json::from_reader(file).unwrap();
-    external.into()
 }
 
 #[cfg(test)]

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -109,12 +109,12 @@ impl Driver<EngineApi> {
         let _addr = rpc::run_server(config.clone()).await?;
 
         let (unsafe_block_signer_sender, unsafe_block_signer_recv) =
-            watch::channel(config.chain.system_config.unsafe_block_singer);
+            watch::channel(config.chain.system_config.unsafe_block_signer);
 
         let (block_handler, unsafe_block_recv) =
-            BlockHandler::new(config.chain.chain_id, unsafe_block_signer_recv);
+            BlockHandler::new(config.chain.l2_chain_id, unsafe_block_signer_recv);
 
-        let service = Service::new("0.0.0.0:9876".parse()?, config.chain.chain_id)
+        let service = Service::new("0.0.0.0:9876".parse()?, config.chain.l2_chain_id)
             .add_handler(Box::new(block_handler));
 
         Ok(Self {
@@ -276,7 +276,7 @@ impl<E: Engine> Driver<E> {
                         let num = l1_info.block_info.number;
 
                         self.unsafe_block_signer_sender
-                            .send(l1_info.system_config.unsafe_block_singer)?;
+                            .send(l1_info.system_config.unsafe_block_signer)?;
 
                         self.pipeline
                             .push_batcher_transactions(l1_info.batcher_transactions.clone(), num)?;

--- a/src/l1/mod.rs
+++ b/src/l1/mod.rs
@@ -217,7 +217,7 @@ impl InnerWatcher {
                 l1_fee_scalar,
                 gas_limit: block.gas_limit,
                 // TODO: fetch from contract
-                unsafe_block_singer: config.chain.system_config.unsafe_block_singer,
+                unsafe_block_signer: config.chain.system_config.unsafe_block_signer,
             }
         };
 
@@ -325,7 +325,7 @@ impl InnerWatcher {
                         config.gas_limit = gas;
                     }
                     SystemConfigUpdate::UnsafeBlockSigner(addr) => {
-                        config.unsafe_block_singer = addr;
+                        config.unsafe_block_signer = addr;
                     }
                 }
 


### PR DESCRIPTION
Closes #150 

Adds support for reading external chain info. It works by simply specifying a file in the `network` flag when running magi.

Example:

```
exec magi \
        --network "./rollup.json" \
        --jwt-secret [...]
```

## Changelog

- fixed a typo across the repo: `unsafe_block_singer`
- added the `l1_chain_id` field to the `ChainConfig` struct, as I think it could be useful and it's usually included in the devnet rollup config
- added the `ExternalChainConfig` struct to make it possible to use external JSON configs. A test has been added which showcases the result of such parsing, with a standard `rollup.json` file created by `op-node`'s devnet command.


## Missing

- the L1 start epoch's timestamp is set to 0 because this information is missing in the rollup.json file. If this will be a problem, we will need to add it to the JSON config somehow.
- The same goes for the `l2_to_l1_message_passer` and `unsafe_block_signer` addresses.