### PR TITLE
Update Debian Version to Resolve GLIBC Compatibility Issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "./bin/network.rs"
 tokio = { version = "1.28.0", features = ["full"] }
 async-trait = "0.1.64"
 eyre = "0.6.8"
-ethers = { version = "2.0.6", features = ["optimism"] }
+ethers = { version = "2.0.8", features = ["optimism"] }
 hex = "0.4.3"
 libflate = "1.2.0"
 openssl = { version = "0.10", features = ["vendored"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ COPY ./ ./
 RUN RUSTFLAGS="$(cat /.rustflags)" cargo build --release --config net.git-fetch-with-cli=true --target $(cat /.platform)
 RUN cp /magi/target/$(cat /.platform)/release/magi /magi/magi
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=build /magi/magi /usr/local/bin

--- a/docker/start-op-geth.sh
+++ b/docker/start-op-geth.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+apk add zstd
+
 DATADIR=/data/geth
 
 if [ $NETWORK = "optimism" ]
@@ -9,8 +11,8 @@ then
     if [ ! -d $DATADIR ]
     then
         mkdir $DATADIR
-        wget "https://storage.googleapis.com/oplabs-mainnet-data/mainnet-bedrock.tar" -P $DATADIR
-        tar -xvf $DATADIR/mainnet-bedrock.tar -C $DATADIR
+        wget "https://datadirs.optimism.io/mainnet-bedrock.tar.zst" -P $DATADIR
+        zstd -cd $DATADIR/mainnet-bedrock.tar.zst | tar xvf - -C $DATADIR
     fi
 elif [ $NETWORK = "base" ]
 then
@@ -27,8 +29,8 @@ then
     if [ ! -d $DATADIR ]
     then
         mkdir $DATADIR
-        wget "https://storage.googleapis.com/oplabs-goerli-data/goerli-bedrock.tar" -P $DATADIR
-        tar -xvf $DATADIR/goerli-bedrock.tar -C $DATADIR
+        wget "https://datadirs.optimism.io/goerli-bedrock.tar.zst" -P $DATADIR
+        zstd -cd $DATADIR/goerli-bedrock.tar.zst | tar xvf - -C $DATADIR
     fi
 elif [ $NETWORK = "base-goerli" ]
 then


### PR DESCRIPTION
## Description of Changes

Currently, the image is being built using the `rust:latest` base image, which is based on `debian:bullseye`, where:

```
ldd --version
ldd (Debian GLIBC 2.31-13+deb11u6) 2.31
```


Then, the final binary is placed in the `debian:buster` image, where version is:

```
ldd --version
ldd (Debian GLIBC 2.28-10+deb10u2) 2.28
```


This leads to an error during application startup, due to a missing `GLIBC_2.29` version, as shown below:

```
magi: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by magi)
```


To resolve this issue and ensure library compatibility, it's recommended to use the same Debian version for both images. In this case, it's proposed to switch from `debian:buster-slim` to `debian:bullseye-slim`.

## Changes in Dockerfile

```diff
-FROM debian:buster-slim
+FROM debian:bullseye-slim
