### PR TITLE
fix(l1): Use tokio `mpsc::channel` instead of std `sync_channel` in L1 watcher

### DIFF
--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -127,8 +127,8 @@ mod tests {
 
             let mut pipeline = Pipeline::new(state.clone(), config.clone(), 0).unwrap();
 
-            chain_watcher.block_update_receiver.recv().unwrap();
-            let update = chain_watcher.block_update_receiver.recv().unwrap();
+            chain_watcher.block_update_receiver.recv().await.unwrap();
+            let update = chain_watcher.block_update_receiver.recv().await.unwrap();
 
             let l1_info = match update {
                 BlockUpdate::NewBlock(block) => *block,


### PR DESCRIPTION
Hey,

Using `std::sync::mpsc::sync_channel` inside `tokio::spawn` can lead to the blocking of the runtime. Since the channel is bounded to 1,000 messages, the runtime might block if the channel becomes full. This behavior can be observed, for instance, when the L1 node is hosted on the same machine and blocks processing fast. We noticed this issue with our local OP devnet setup.

By replacing `sync_channel` with `tokio::sync::mpsc::channel`, we can circumvent this issue. If the channel becomes full using the latter, it won't block the runtime.