### PR TITLE
fix(env): Change test env endpoints to goerli

### DIFF
--- a/docker/.env.default
+++ b/docker/.env.default
@@ -36,8 +36,8 @@ OP_CHALLENGER_SIGNER_KEY=a1742ee5f7898541224d6a91d9f3b34ad442e27bcb43223c01e47e5
 
 
 # --------------------- Only needed for testing locally ---------------------
-L1_TEST_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/<API_KEY>
-L2_TEST_RPC_URL=https://opt-mainnet.g.alchemy.com/v2/<API_KEY>
+L1_TEST_RPC_URL=https://eth-goerli.g.alchemy.com/v2/<API_KEY>
+L2_TEST_RPC_URL=https://opt-goerli.g.alchemy.com/v2/<API_KEY>
 
 
 # ------------------------------ Do not modify ------------------------------


### PR DESCRIPTION
Hey,

Since both `L1_TEST_RPC_URL` and `L2_TEST_RPC_URL` need to be Goerli endpoints to run tests, I believe it would be logical to update them in `.env.default`.