### PR TITLE
[docker] Fix glibc problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM --platform=$BUILDPLATFORM rust:latest as build
+FROM --platform=$BUILDPLATFORM debian:bullseye-slim as base
+RUN apt update && apt install -y libudev-dev build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof lld
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH "$PATH:/root/.cargo/bin"
+
+FROM base as build
 WORKDIR /magi
 ARG TARGETARCH
-
 COPY ./platform.sh .
 RUN ./platform.sh
 RUN rustup target add $(cat /.platform) 


### PR DESCRIPTION
We have once again encountered an issue with glibc on arch64:

```
magi: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by magi)
magi  | magi: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by magi)
magi  | magi: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by magi)
magi  | magi: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by magi)
magi  | magi: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by magi)
```

As you can see, the versions differ again between the `rust:latest` image and `debian:bullseye-slim`: 

rust:latest
```
root@aed8602b702f:/# ldd --version
ldd (Debian GLIBC 2.36-9+deb12u1) 2.36
```

debian:bullseye-slim

```
root@76e82549a3bc:/# ldd --version
ldd (Debian GLIBC 2.31-13+deb11u6) 2.31
```

Of course, we can quickly fix this by changing the version to `debian:bookworm-slim`, but this is a temporary solution, and we are likely to encounter this problem again. Another approach is to pin the Rust version firmly, but this is not ideal either. Alternatively, we could compare the versions in the base images each time before building the images, but this is also not really good solution. 

Therefore, I propose always using a single image for all stages and installing the necessary packages and dependencies as needed. This way, we can eliminate this problem.