### PR TITLE
chore(docker): ignore Git files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,4 @@
+.git/
+.github/
+.gitignore
 target/


### PR DESCRIPTION
There's no need to copy the `.git`/`.github` directories or the `.gitignore` for the Docker build.