### PR TITLE
feat: Sepolia support

### DIFF
--- a/bin/magi.rs
+++ b/bin/magi.rs
@@ -69,6 +69,7 @@ impl Cli {
         let chain = match self.network.as_str() {
             "optimism" => ChainConfig::optimism(),
             "optimism-goerli" => ChainConfig::optimism_goerli(),
+            "optimism-sepolia" => ChainConfig::optimism_sepolia(),
             "base" => ChainConfig::base(),
             "base-goerli" => ChainConfig::base_goerli(),
             file if file.ends_with(".json") => ChainConfig::from_json(file),

--- a/docker/.env.default
+++ b/docker/.env.default
@@ -1,4 +1,4 @@
-# L1 network option: can be either `optimism`, `optimism-goerli` or `base-goerli`
+# L1 network option: can be either `optimism`, `optimism-goerli`, `optimism-sepolia` or `base-goerli`
 NETWORK=optimism
 
 # The HTTP RPC endpoint of an L1 node

--- a/docker/start-op-geth.sh
+++ b/docker/start-op-geth.sh
@@ -32,6 +32,14 @@ then
         wget "https://datadirs.optimism.io/goerli-bedrock.tar.zst" -P $DATADIR
         zstd -cd $DATADIR/goerli-bedrock.tar.zst | tar xvf - -C $DATADIR
     fi
+elif [ "$NETWORK" = "optimism-sepolia" ]
+then
+    CHAIN_ID=11155420
+    if [ ! -d "$DATADIR" ]
+    then
+        wget "https://storage.googleapis.com/oplabs-network-data/Sepolia/genesis.json" -O ./genesis-l2.json
+        geth init --datadir=$DATADIR ./genesis-l2.json
+    fi
 elif [ $NETWORK = "base-goerli" ]
 then
     CHAIN_ID=84531

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -288,6 +288,43 @@ impl ChainConfig {
             blocktime: 2,
         }
     }
+    pub fn optimism_sepolia() -> Self {
+        Self {
+            network: "optimism-sepolia".to_string(),
+            l1_chain_id: 11155111,
+            l2_chain_id: 11155420,
+            l1_start_epoch: Epoch {
+                hash: hash("0x48f520cf4ddaf34c8336e6e490632ea3cf1e5e93b0b2bc6e917557e31845371b"),
+                number: 4071408,
+                timestamp: 1691802540,
+            },
+            l2_genesis: BlockInfo {
+                hash: hash("0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"),
+                number: 0,
+                parent_hash: hash(
+                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                ),
+                timestamp: 1691802540,
+            },
+            system_config: SystemConfig {
+                batch_sender: addr("0x8F23BB38F531600e5d8FDDaAEC41F13FaB46E98c"),
+                gas_limit: U256::from(30_000_000),
+                l1_fee_overhead: U256::from(188),
+                l1_fee_scalar: U256::from(684000),
+                unsafe_block_signer: addr("0x0000000000000000000000000000000000000000"),
+            },
+            system_config_contract: addr("0x034edd2a225f7f429a63e0f1d2084b9e0a93b538"),
+            batch_inbox: addr("0xff00000000000000000000000000000011155420"),
+            deposit_contract: addr("0x16fc5058f25648194471939df75cf27a2fdc48bc"),
+            l2_to_l1_message_passer: addr("0x4200000000000000000000000000000000000016"),
+            max_channel_size: 100_000_000,
+            channel_timeout: 300,
+            seq_window_size: 3600,
+            max_seq_drift: 600,
+            regolith_time: 0,
+            blocktime: 2,
+        }
+    }
 
     pub fn base() -> Self {
         Self {

--- a/src/derive/state.rs
+++ b/src/derive/state.rs
@@ -55,10 +55,6 @@ impl State {
         })
     }
 
-    pub fn is_full(&self) -> bool {
-        self.current_epoch_num > self.safe_epoch.number + 1000
-    }
-
     pub fn update_l1_info(&mut self, l1_info: L1Info) {
         self.current_epoch_num = l1_info.block_info.number;
 


### PR DESCRIPTION
Hey team,

We've introduced support for the Sepolia network along with the necessary configurations. Additionally, we've implemented several fixes and updates as outlined in [Issue #166](https://github.com/a16z/magi/issues/166).

Specifically, we've removed the `state.is_full` check. Now, we update the state once the attributes are processed. Without this change, the system was entering an infinite loop, producing blocks with identical timestamps and data. These were subsequently rejected by `op-eth`. Referring to the following section for context:

https://github.com/a16z/magi/blob/36e3e07b46822c0354e5a3d94beb97c522980e02/src/derive/stages/batches.rs#L104-L138