### PR TITLE
feat: JWT Secret PathBuf

### DIFF
--- a/bin/magi.rs
+++ b/bin/magi.rs
@@ -1,4 +1,5 @@
-use std::process;
+use std::path::PathBuf;
+use std::{env::current_dir, process};
 
 use clap::Parser;
 use dirs::home_dir;
@@ -50,6 +51,9 @@ pub struct Cli {
     l2_engine_url: Option<String>,
     #[clap(long)]
     jwt_secret: Option<String>,
+    /// Path to a JWT secret to use for authenticated RPC endpoints
+    #[clap(long, global = true, required = false)]
+    jwt_file: Option<PathBuf>,
     #[clap(short = 'v', long)]
     verbose: bool,
     #[clap(short = 'p', long)]
@@ -84,15 +88,39 @@ impl Cli {
         let cli_config = CliConfig::from(self);
         Config::new(&config_path, cli_config, chain)
     }
+
+    pub fn jwt_secret(&self) -> Option<String> {
+        self.jwt_secret.clone().or(self.jwt_secret_from_file())
+    }
+
+    pub fn jwt_secret_from_file(&self) -> Option<String> {
+        let jwt_file = self.jwt_file.as_ref()?;
+        match std::fs::read_to_string(jwt_file) {
+            Ok(content) => Some(content),
+            Err(_) => Cli::default_jwt_secret(),
+        }
+    }
+
+    pub fn default_jwt_secret() -> Option<String> {
+        let cur_dir = current_dir().ok()?;
+        match std::fs::read_to_string(cur_dir.join("jwt.hex")) {
+            Ok(content) => Some(content),
+            Err(_) => {
+                tracing::error!(target: "magi", "Failed to read JWT secret from file: {:?}", cur_dir);
+                None
+            }
+        }
+    }
 }
 
 impl From<Cli> for CliConfig {
     fn from(value: Cli) -> Self {
+        let jwt_secret = value.jwt_secret();
         Self {
             l1_rpc_url: value.l1_rpc_url,
             l2_rpc_url: value.l2_rpc_url,
             l2_engine_url: value.l2_engine_url,
-            jwt_secret: value.jwt_secret,
+            jwt_secret,
             checkpoint_sync_url: value.checkpoint_sync_url,
             rpc_port: value.rpc_port,
         }

--- a/bin/magi.rs
+++ b/bin/magi.rs
@@ -52,7 +52,7 @@ pub struct Cli {
     #[clap(long)]
     jwt_secret: Option<String>,
     /// Path to a JWT secret to use for authenticated RPC endpoints
-    #[clap(long, global = true, required = false)]
+    #[clap(long)]
     jwt_file: Option<PathBuf>,
     #[clap(short = 'v', long)]
     verbose: bool,


### PR DESCRIPTION
**Description**

Adds a `jwt_file` field to the cli.

This allows users to specify a file containing the jwt token hex string via the `--jwt-file` flag as an alternative to passing the token hex string to the `--jwt-secret` flag.

Allows for magi to work more seamlessly with trusted nodes by sharing the jwt token file.