### PR TITLE
fix(config): default message parser address

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -502,7 +502,7 @@ impl From<ExternalChainConfig> for ChainConfig {
             max_seq_drift: external.max_sequencer_drift,
             regolith_time: external.regolith_time,
             blocktime: external.block_time,
-            l2_to_l1_message_passer: Address::zero(),
+            l2_to_l1_message_passer: addr("0x4200000000000000000000000000000000000016"),
         }
     }
 }


### PR DESCRIPTION
For external configurations, let's utilize the [default message parser address](https://github.com/ethereum-optimism/optimism/blob/56c7254726619826cc5647250922a2c56ecd0d39/op-bindings/predeploys/addresses.go#L9). Without this, the RPC `optimism_outputAtBlock` endpoint may not function correctly with external setups.

In the future, we might consider allowing this value to be passed via a CLI parameter for some cases. However, the current approach seems to be the most optimal for now.