### PR TITLE
fix(clippy): use first() instead of get(0)

### DIFF
--- a/src/driver/types.rs
+++ b/src/driver/types.rs
@@ -21,7 +21,7 @@ impl TryFrom<Block<Transaction>> for HeadInfo {
     fn try_from(value: Block<Transaction>) -> Result<Self> {
         let tx_calldata = value
             .transactions
-            .get(0)
+            .first()
             .ok_or(eyre::eyre!(
                 "Could not find the L1 attributes deposited transaction"
             ))?

--- a/src/l1/mod.rs
+++ b/src/l1/mod.rs
@@ -212,7 +212,7 @@ impl InnerWatcher {
 
             let input = &block
                 .transactions
-                .get(0)
+                .first()
                 .expect(
                     "Could not find the L1 attributes deposited transaction in the parent L2 block",
                 )


### PR DESCRIPTION
Clippy introduces the [`get_first` rule](https://rust-lang.github.io/rust-clippy/master/index.html#/get_first) which prefers `first()` instead of `first(0)`. In recent nightly toolchain updates, the `clippy` action [fails](https://github.com/SpecularL2/magi/actions/runs/6607922576/job/17980361805) because of the above rule.

In this pr, both places, where attribute deposit transaction is obtained from the transaction list, are changed from `transactions.get(0)` to `transaction.first()`.