### PR TITLE
Feat: RPC support (part 1)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     volumes:
       - ./:/scripts
       - data:/data
-      - ${OP_GENESIS_JSON_FILEPATH:-.}:/genesis-l2.json
+      - ${OP_GENESIS_JSON_FILEPATH:-.}:/genesis-l2-attached.json
     <<: *logging
 
   op-erigon:

--- a/docker/start-op-geth.sh
+++ b/docker/start-op-geth.sh
@@ -51,12 +51,12 @@ then
     fi
 elif [ $NETWORK = "custom" ] || [ $NETWORK = "devnet" ]
 then
-    CHAIN_ID=$(jq '.config.chainId' ./genesis-l2.json)
+    CHAIN_ID=$(jq '.config.chainId' ./genesis-l2-attached.json)
     
     if [ ! -d $DATADIR ]
     then
         mkdir $DATADIR
-        geth init --datadir=$DATADIR ./genesis-l2.json
+        geth init --datadir=$DATADIR ./genesis-l2-attached.json
     fi
 else
     echo "Network not recognized. Available options are optimism-goerli and base-goerli"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,3 +27,6 @@ pub mod rpc;
 
 /// A module to handle running Magi in different sync modes
 pub mod runner;
+
+/// A module to get current Magi version.
+pub mod version;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,6 +1,9 @@
 use std::{fmt::Display, net::SocketAddr, sync::Arc};
 
-use crate::{config::Config, version::Version};
+use crate::{
+    config::{Config, ExternalChainConfig},
+    version::Version,
+};
 
 use eyre::Result;
 
@@ -22,6 +25,9 @@ use serde::{Deserialize, Serialize};
 pub trait Rpc {
     #[method(name = "outputAtBlock")]
     async fn output_at_block(&self, block_number: u64) -> Result<OutputRootResponse, Error>;
+
+    #[method(name = "rollupConfig")]
+    async fn rollup_config(&self) -> Result<ExternalChainConfig, Error>;
 
     #[method(name = "version")]
     async fn version(&self) -> Result<String, Error>;
@@ -69,6 +75,12 @@ impl RpcServer for RpcServerImpl {
             state_root,
             withdrawal_storage_root,
         })
+    }
+
+    async fn rollup_config(&self) -> Result<ExternalChainConfig, Error> {
+        let config = (*self.config).clone();
+
+        Ok(ExternalChainConfig::from(config.chain))
     }
 
     async fn version(&self) -> Result<String, Error> {

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -1,0 +1,39 @@
+#[derive(Debug)]
+pub struct Version {
+    name: String,
+    version: String,
+    meta: String,
+}
+
+impl Version {
+    pub fn build() -> Self {
+        let meta = if cfg!(debug_assertions) {
+            "dev"
+        } else {
+            "release"
+        };
+
+        Version {
+            name: env!("CARGO_PKG_NAME").to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            meta: meta.to_string(),
+        }
+    }
+}
+
+impl ToString for Version {
+    fn to_string(&self) -> String {
+        format!("{}{}-{}", self.name, self.version, self.meta)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::version::Version;
+
+    #[test]
+    fn version() {
+        let version = Version::build();
+        assert!(version.to_string() == "magi0.1.0-dev");
+    }
+}


### PR DESCRIPTION
Per the RPC standard, there are several additional RPC endpoints that need to be supported beyond what Magi currently offers, including `version`, `rollupConfig`, and `syncStatus`. Furthermore, enhancements to `getOutputAtBlock` are necessary.

The present PR addresses the `version` and `rollupConfig` endpoints. Subsequent PRs will cover the remaining requirements. Note that I've already implemented `syncStatus` in a private fork and would move ASAP.

The RPC is important part as batcher uses RPC and by itself it's important to have full 
capability.

Also the PR contains fix for docker compose. 