### PR TITLE
fix: op geth script

### DIFF
--- a/docker/start-op-geth.sh
+++ b/docker/start-op-geth.sh
@@ -80,7 +80,6 @@ exec geth \
   --http.api=web3,debug,eth,txpool,net,engine,admin \
   --syncmode=full \
   --gcmode=full \
-  --networkid=420 \
   --authrpc.vhosts="*" \
   --authrpc.addr=0.0.0.0 \
   --authrpc.port=8551 \


### PR DESCRIPTION
The start-op-geth.sh has a repeat option of networkid.
It may cause some unexpected problem.