### PR TITLE
chore(docs): update expired links

### DIFF
--- a/src/engine/traits.rs
+++ b/src/engine/traits.rs
@@ -33,7 +33,7 @@ pub trait Engine: Send + Sync + 'static {
     ///
     /// ### Reference
     ///
-    /// See more details in the [Optimism Specs](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md#engine_forkchoiceupdatedv1).
+    /// See more details in the [Optimism Specs](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_forkchoiceupdatedv1).
     async fn forkchoice_updated(
         &self,
         forkchoice_state: ForkchoiceState,
@@ -58,7 +58,7 @@ pub trait Engine: Send + Sync + 'static {
     ///
     /// ### Reference
     ///
-    /// See more details in the [Optimism Specs](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md#engine_newPayloadv1).
+    /// See more details in the [Optimism Specs](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_newpayloadv1).
     async fn new_payload(&self, execution_payload: ExecutionPayload) -> Result<PayloadStatus>;
 
     /// ## get_payload
@@ -80,6 +80,6 @@ pub trait Engine: Send + Sync + 'static {
     ///
     /// ### Reference
     ///
-    /// See more details in the [Optimism Specs](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md#engine_getPayloadv1).
+    /// See more details in the [Optimism Specs](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_getpayloadv1).
     async fn get_payload(&self, payload_id: PayloadId) -> Result<ExecutionPayload>;
 }


### PR DESCRIPTION
Some chore issues were found when reading the codebase.

Due to the development of optimism, some of the links in the documentation are outdated; for example, these function descriptions in the develop branch have now been merged into the main branch.

Currently, in Spec, e.g., new_payload and forkchoice_updated have been updated to version V2, which is slightly different from version 1.