### PR TITLE
20240210 fix op links

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ The Pipeline is broken up into [stages](../src/derive/stages/mod.rs) as follows.
 
 ##### Batcher Transactions
 
-The [Batcher Transactions](../src/derive/stages/batcher_transactions.rs) stage pulls transactions from its configured channel receiver, passed down from the [Pipeline](../src/derive/mod.rs) parent. To construct a [Batcher Transaction](../src/derive/stages/batcher_transactions.rs) from the raw transaction data, it constructs [Frames](../src/derive/stages/batcher_transactions.rs) following the [Batch Submission Wire Format](https://github.com/ethereum-optimism/optimism/blob/develop/specs/derivation.md#batch-submission-wire-format) documented in the [Optimism Specs](https://github.com/ethereum-optimism/optimism/blob/develop/specs/README.md).
+The [Batcher Transactions](../src/derive/stages/batcher_transactions.rs) stage pulls transactions from its configured channel receiver, passed down from the [Pipeline](../src/derive/mod.rs) parent. To construct a [Batcher Transaction](../src/derive/stages/batcher_transactions.rs) from the raw transaction data, it constructs [Frames](../src/derive/stages/batcher_transactions.rs) following the [Batch Submission Wire Format](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/derivation.md#batch-submission-wire-format) documented in the [Optimism Specs](https://github.com/ethereum-optimism/specs/tree/main).
 
 ##### Channels
 
@@ -44,7 +44,7 @@ Remember, since the [L1 Chain Watcher](#l1-chain-watcher) is spawned as a separa
 
 ##### Batches
 
-Next up, the [Batches](../src/derive/stages/batches.rs) stage iterates over the prior [Channel](../src/derive/stages/channels.rs) stage, decoding [Batch](../src/derive/stages/batches.rs) objects from the inner channel data. [Batch](../src/derive/stages/batches.rs) objects are RLP-decoded from the channel data following the [Batch Encoding Format](https://github.com/ethereum-optimism/optimism/blob/develop/specs/derivation.md#batch-format), detailed below.
+Next up, the [Batches](../src/derive/stages/batches.rs) stage iterates over the prior [Channel](../src/derive/stages/channels.rs) stage, decoding [Batch](../src/derive/stages/batches.rs) objects from the inner channel data. [Batch](../src/derive/stages/batches.rs) objects are RLP-decoded from the channel data following the [Batch Encoding Format](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/derivation.md#batch-format), detailed below.
 
 For version 0, [Batch](../src/derive/stages/batches.rs) objects are encoded as follows:
 

--- a/src/engine/payload.rs
+++ b/src/engine/payload.rs
@@ -82,7 +82,7 @@ impl TryFrom<Block<Transaction>> for ExecutionPayload {
 /// ## PayloadAttributes
 ///
 /// L2 extended payload attributes for Optimism.
-/// For more details, visit the [Optimism specs](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md#extended-payloadattributesv1).
+/// For more details, visit the [Optimism specs](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/exec-engine.md#extended-payloadattributesv1).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PayloadAttributes {

--- a/src/engine/traits.rs
+++ b/src/engine/traits.rs
@@ -10,7 +10,7 @@ use super::{
 ///
 /// A set of methods that allow a consensus client to interact with an execution engine.
 /// This is a modified version of the [Ethereum Execution API Specs](https://github.com/ethereum/execution-apis),
-/// as defined in the [Optimism Exec Engine Specs](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md).
+/// as defined in the [Optimism Exec Engine Specs](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/exec-engine.md).
 #[async_trait]
 pub trait Engine: Send + Sync + 'static {
     /// ## forkchoice_updated
@@ -33,7 +33,7 @@ pub trait Engine: Send + Sync + 'static {
     ///
     /// ### Reference
     ///
-    /// See more details in the [Optimism Specs](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md#engine_forkchoiceupdatedv1).
+    /// See more details in the [Optimism Specs](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/exec-engine.md#engine_forkchoiceupdatedv1).
     async fn forkchoice_updated(
         &self,
         forkchoice_state: ForkchoiceState,
@@ -58,7 +58,7 @@ pub trait Engine: Send + Sync + 'static {
     ///
     /// ### Reference
     ///
-    /// See more details in the [Optimism Specs](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md#engine_newPayloadv1).
+    /// See more details in the [Optimism Specs](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/exec-engine.md#engine_newPayloadv1).
     async fn new_payload(&self, execution_payload: ExecutionPayload) -> Result<PayloadStatus>;
 
     /// ## get_payload
@@ -80,6 +80,6 @@ pub trait Engine: Send + Sync + 'static {
     ///
     /// ### Reference
     ///
-    /// See more details in the [Optimism Specs](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md#engine_getPayloadv1).
+    /// See more details in the [Optimism Specs](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/exec-engine.md#engine_getPayloadv1).
     async fn get_payload(&self, payload_id: PayloadId) -> Result<ExecutionPayload>;
 }


### PR DESCRIPTION
Hello, 
I've found, that several links both in docs and code are pointing to outdated optimism specs, which [has moved](https://github.com/ethereum-optimism/optimism/blob/develop/specs/README.md) to [fresh repo](https://github.com/ethereum-optimism/specs). 
This PR updates the broken links to new repo. Updates are prepared for all occurrences without any code change.

@ncitron 