### PR TITLE
chore(config): Migrate more types to Alloy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "hex-literal",
  "itoa",
  "ruint",
+ "serde",
  "tiny-keccak",
 ]
 
@@ -2333,6 +2334,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-literal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ futures-timer = "0.3.0"
 again = "0.1"
 
 # Alloy types
-alloy-primitives = { version = "0.7.1", default-features = false }
+alloy-primitives = { version = "0.7.1", default-features = false, features = ["serde"] }
 
 # Logging and Metrics
 chrono = "0.4.22"

--- a/src/common/attributes_deposited.rs
+++ b/src/common/attributes_deposited.rs
@@ -96,9 +96,9 @@ impl AttributesDepositedCall {
         let hash = B256::from_slice(&calldata[cursor..cursor + 32]);
         cursor += 32;
 
-        let seq_num = U256::from_be_slice(calldata[cursor..cursor + 32].try_into()?);
+        let sequence_number = U256::from_be_slice(calldata[cursor..cursor + 32].try_into()?);
         // down-casting to u64 is safe for the sequence number
-        let seq_num = seq_num
+        let sequence_number = sequence_number
             .try_into()
             .map_err(|_| eyre::eyre!("invalid sequence number"))?;
         cursor += 32;
@@ -116,7 +116,7 @@ impl AttributesDepositedCall {
             timestamp,
             basefee,
             hash,
-            sequence_number: seq_num,
+            sequence_number,
             batcher_hash,
             fee_overhead,
             fee_scalar,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,7 +1,8 @@
 use std::fmt::Debug;
 
+use alloy_primitives::B256;
 use ethers::{
-    types::{Block, Transaction, H256},
+    types::{Block, Transaction},
     utils::rlp::{Decodable, DecoderError, Rlp},
 };
 use eyre::Result;
@@ -18,11 +19,11 @@ pub use attributes_deposited::AttributesDepositedCall;
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct BlockInfo {
     /// The block hash
-    pub hash: H256,
+    pub hash: B256,
     /// The block number
     pub number: u64,
     /// The parent block hash
-    pub parent_hash: H256,
+    pub parent_hash: B256,
     /// The block timestamp
     pub timestamp: u64,
 }
@@ -37,7 +38,7 @@ pub struct Epoch {
     /// The block number
     pub number: u64,
     /// The block hash
-    pub hash: H256,
+    pub hash: B256,
     /// The block timestamp
     pub timestamp: u64,
 }
@@ -45,12 +46,12 @@ pub struct Epoch {
 impl From<BlockInfo> for Value {
     fn from(value: BlockInfo) -> Value {
         let mut dict = Dict::new();
-        dict.insert("hash".to_string(), Value::from(value.hash.as_bytes()));
+        dict.insert("hash".to_string(), Value::from(value.hash.as_slice()));
         dict.insert("number".to_string(), Value::from(value.number));
         dict.insert("timestamp".to_string(), Value::from(value.timestamp));
         dict.insert(
             "parent_hash".to_string(),
-            Value::from(value.parent_hash.as_bytes()),
+            Value::from(value.parent_hash.as_slice()),
         );
         Value::Dict(Tag::Default, dict)
     }
@@ -70,8 +71,8 @@ impl TryFrom<Block<Transaction>> for BlockInfo {
 
         Ok(BlockInfo {
             number,
-            hash,
-            parent_hash: block.parent_hash,
+            hash: B256::from_slice(hash.as_bytes()),
+            parent_hash: B256::from_slice(block.parent_hash.as_bytes()),
             timestamp: block.timestamp.as_u64(),
         })
     }
@@ -80,7 +81,7 @@ impl TryFrom<Block<Transaction>> for BlockInfo {
 impl From<Epoch> for Value {
     fn from(value: Epoch) -> Self {
         let mut dict = Dict::new();
-        dict.insert("hash".to_string(), Value::from(value.hash.as_bytes()));
+        dict.insert("hash".to_string(), Value::from(value.hash.as_slice()));
         dict.insert("number".to_string(), Value::from(value.number));
         dict.insert("timestamp".to_string(), Value::from(value.timestamp));
         Value::Dict(Tag::Default, dict)
@@ -92,8 +93,8 @@ impl From<&ExecutionPayload> for BlockInfo {
     fn from(value: &ExecutionPayload) -> Self {
         Self {
             number: value.block_number.as_u64(),
-            hash: value.block_hash,
-            parent_hash: value.parent_hash,
+            hash: B256::from_slice(value.block_hash.as_bytes()),
+            parent_hash: B256::from_slice(value.parent_hash.as_bytes()),
             timestamp: value.timestamp.as_u64(),
         }
     }
@@ -105,7 +106,7 @@ impl From<&AttributesDepositedCall> for Epoch {
         Self {
             number: call.number,
             timestamp: call.timestamp,
-            hash: H256::from_slice(call.hash.as_slice()),
+            hash: B256::from_slice(call.hash.as_slice()),
         }
     }
 }

--- a/src/derive/stages/batches.rs
+++ b/src/derive/stages/batches.rs
@@ -204,7 +204,7 @@ where
         }
 
         // check that block builds on existing chain
-        if batch.parent_hash != head.hash {
+        if alloy_primitives::B256::from_slice(batch.parent_hash.as_bytes()) != head.hash {
             tracing::warn!("invalid parent hash");
             return BatchStatus::Drop;
         }
@@ -226,7 +226,8 @@ where
         };
 
         if let Some(batch_origin) = batch_origin {
-            if batch.epoch_hash != batch_origin.hash {
+            if alloy_primitives::B256::from_slice(batch.epoch_hash.as_bytes()) != batch_origin.hash
+            {
                 tracing::warn!("invalid epoch hash");
                 return BatchStatus::Drop;
             }
@@ -323,7 +324,7 @@ where
 
         // check that block builds on existing chain
 
-        if prev_l2_block.hash.as_bytes()[..20] != batch.parent_check {
+        if prev_l2_block.hash.as_slice()[..20] != batch.parent_check {
             tracing::warn!("batch parent check failed");
             return BatchStatus::Drop;
         }
@@ -341,7 +342,7 @@ where
         }
 
         if let Some(l1_origin) = state.epoch_by_number(end_epoch_num) {
-            if batch.l1_origin_check != l1_origin.hash.as_bytes()[..20] {
+            if batch.l1_origin_check != l1_origin.hash.as_slice()[..20] {
                 tracing::warn!("origin check failed");
                 return BatchStatus::Drop;
             }

--- a/src/derive/state.rs
+++ b/src/derive/state.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
+use alloy_primitives::B256;
 use ethers::{
     providers::{Http, Middleware, Provider},
     types::H256,
@@ -76,7 +77,7 @@ impl State {
     pub fn epoch_by_hash(&self, hash: H256) -> Option<Epoch> {
         self.l1_info_by_hash(hash).map(|info| Epoch {
             number: info.block_info.number,
-            hash: info.block_info.hash,
+            hash: B256::from_slice(info.block_info.hash.as_bytes()),
             timestamp: info.block_info.timestamp,
         })
     }
@@ -85,7 +86,7 @@ impl State {
     pub fn epoch_by_number(&self, num: u64) -> Option<Epoch> {
         self.l1_info_by_number(num).map(|info| Epoch {
             number: info.block_info.number,
-            hash: info.block_info.hash,
+            hash: B256::from_slice(info.block_info.hash.as_bytes()),
             timestamp: info.block_info.timestamp,
         })
     }

--- a/src/driver/engine_driver.rs
+++ b/src/driver/engine_driver.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use alloy_primitives::B256;
 use ethers::providers::{Http, Middleware, Provider};
 use ethers::types::Transaction;
 use ethers::{
@@ -100,8 +101,8 @@ impl<E: Engine> EngineDriver<E> {
 
         let new_head = BlockInfo {
             number: payload.block_number.as_u64(),
-            hash: payload.block_hash,
-            parent_hash: payload.parent_hash,
+            hash: B256::from_slice(payload.block_hash.as_bytes()),
+            parent_hash: B256::from_slice(payload.parent_hash.as_bytes()),
             timestamp: payload.timestamp.as_u64(),
         };
 
@@ -198,9 +199,9 @@ impl<E: Engine> EngineDriver<E> {
     /// - `finalized_block` = `finalized_head`
     fn create_forkchoice_state(&self) -> ForkchoiceState {
         ForkchoiceState {
-            head_block_hash: self.unsafe_head.hash,
-            safe_block_hash: self.safe_head.hash,
-            finalized_block_hash: self.finalized_head.hash,
+            head_block_hash: H256::from_slice(self.unsafe_head.hash.as_slice()),
+            safe_block_hash: H256::from_slice(self.safe_head.hash.as_slice()),
+            finalized_block_hash: H256::from_slice(self.finalized_head.hash.as_slice()),
         }
     }
 

--- a/src/driver/info.rs
+++ b/src/driver/info.rs
@@ -79,8 +79,7 @@ mod test_utils {
     use super::*;
     use crate::common::{BlockInfo, Epoch};
     use crate::config::{ChainConfig, Config};
-    use ethers::types::H256;
-    use std::str::FromStr;
+    use alloy_primitives::b256;
 
     pub struct MockProvider {
         pub block: Option<Block<Transaction>>,
@@ -93,23 +92,16 @@ mod test_utils {
     pub fn default_head_info() -> HeadInfo {
         HeadInfo {
             l2_block_info: BlockInfo {
-                hash: H256::from_str(
-                    "dbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3",
-                )
-                .unwrap(),
+                hash: b256!("dbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3"),
                 number: 105235063,
-                parent_hash: H256::from_str(
-                    "21a168dfa5e727926063a28ba16fd5ee84c814e847c81a699c7a0ea551e4ca50",
-                )
-                .unwrap(),
+                parent_hash: b256!(
+                    "21a168dfa5e727926063a28ba16fd5ee84c814e847c81a699c7a0ea551e4ca50"
+                ),
                 timestamp: 1686068903,
             },
             l1_epoch: Epoch {
                 number: 17422590,
-                hash: H256::from_str(
-                    "438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108",
-                )
-                .unwrap(),
+                hash: b256!("438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"),
                 timestamp: 1686068903,
             },
             sequence_number: 0,

--- a/src/driver/types.rs
+++ b/src/driver/types.rs
@@ -78,6 +78,7 @@ mod tests {
         use crate::driver::HeadInfo;
         use std::str::FromStr;
 
+        use alloy_primitives::b256;
         use ethers::{
             providers::{Middleware, Provider},
             types::{Block, Transaction, H256},
@@ -181,14 +182,13 @@ mod tests {
 
             let block: Block<Transaction> = serde_json::from_str(raw_block)?;
 
-            let expected_l2_block_hash = H256::from_str(
-                "0x2e4f4aff36bb7951be9742ad349fb1db84643c6bbac5014f3d196fd88fe333eb",
-            )?;
+            let expected_l2_block_hash =
+                b256!("2e4f4aff36bb7951be9742ad349fb1db84643c6bbac5014f3d196fd88fe333eb");
             let expected_l2_block_number = 8381743;
             let expected_l2_block_timestamp = 1682191554;
 
             let expected_l1_epoch_hash =
-                H256::from_str("0444c991c5fe1d7291ff34b3f5c3b44ee861f021396d33ba3255b83df30e357d")?;
+                b256!("0444c991c5fe1d7291ff34b3f5c3b44ee861f021396d33ba3255b83df30e357d");
             let expected_l1_epoch_block_number = 8874020;
             let expected_l1_epoch_timestamp = 1682191440;
 
@@ -221,15 +221,14 @@ mod tests {
             if std::env::var("L1_TEST_RPC_URL").is_ok() && std::env::var("L2_TEST_RPC_URL").is_ok()
             {
                 let l2_block_hash = H256::from_str(
-                    "0x75d4a658d7b6430c874c5518752a8d90fb1503eccd6ae4cfc97fd4aedeebb939",
+                    "75d4a658d7b6430c874c5518752a8d90fb1503eccd6ae4cfc97fd4aedeebb939",
                 )?;
 
                 let expected_l2_block_number = 8428108;
                 let expected_l2_block_timestamp = 1682284284;
 
-                let expected_l1_epoch_hash = H256::from_str(
-                    "0x76ab90dc2afea158bbe14a99f22d5f867b51719378aa37d1a3aa3833ace67cad",
-                )?;
+                let expected_l1_epoch_hash =
+                    b256!("76ab90dc2afea158bbe14a99f22d5f867b51719378aa37d1a3aa3833ace67cad");
                 let expected_l1_epoch_block_number = 8879997;
                 let expected_l1_epoch_timestamp = 1682284164;
 
@@ -263,6 +262,7 @@ mod tests {
         use crate::driver::HeadInfo;
         use std::str::FromStr;
 
+        use alloy_primitives::b256;
         use ethers::{
             providers::{Middleware, Provider},
             types::H256,
@@ -280,9 +280,8 @@ mod tests {
                 let expected_l2_block_number = 21564471;
                 let expected_l2_block_timestamp = 1708557010;
 
-                let expected_l1_epoch_hash = H256::from_str(
-                    "0x231ac984a3fc58757efe373b0b5bff0589c0e67a969a6cbc56ec959739525b31",
-                )?;
+                let expected_l1_epoch_hash =
+                    b256!("231ac984a3fc58757efe373b0b5bff0589c0e67a969a6cbc56ec959739525b31");
                 let expected_l1_epoch_block_number = 10575507;
                 let expected_l1_epoch_timestamp = 1708556928;
 

--- a/src/engine/payload.rs
+++ b/src/engine/payload.rs
@@ -64,7 +64,7 @@ impl TryFrom<Block<Transaction>> for ExecutionPayload {
 
         Ok(ExecutionPayload {
             parent_hash: value.parent_hash,
-            fee_recipient: SystemAccounts::default().fee_vault,
+            fee_recipient: H160::from_slice(SystemAccounts::default().fee_vault.as_slice()),
             state_root: value.state_root,
             receipts_root: value.receipts_root,
             logs_bloom: value.logs_bloom.unwrap().as_bytes().to_vec().into(),

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -9,7 +9,7 @@ use eyre::Result;
 
 use ethers::{
     providers::{Middleware, Provider},
-    types::{Block, BlockId, H256},
+    types::{Address, Block, BlockId, H256},
     utils::keccak256,
 };
 
@@ -67,7 +67,7 @@ impl RpcServer for RpcServerImpl {
         let state_proof = convert_err(
             l2_provider
                 .get_proof(
-                    self.config.chain.l2_to_l1_message_passer,
+                    Address::from_slice(self.config.chain.l2_to_l1_message_passer.as_slice()),
                     locations,
                     block_id,
                 )

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -230,10 +230,13 @@ impl Runner {
             .await?
             .ok_or_else(|| eyre::eyre!("could not find block"))?;
 
+        let predeploy = ethers::types::Address::from_slice(
+            SystemAccounts::default().attributes_predeploy.as_slice(),
+        );
         let sequence_number = &l2_block
             .transactions
             .iter()
-            .find(|tx| tx.to.unwrap() == SystemAccounts::default().attributes_predeploy)
+            .find(|tx| tx.to.map_or(false, |to| to == predeploy))
             .expect("could not find setL1BlockValues tx in the epoch boundary search")
             .input
             .clone()


### PR DESCRIPTION
**Description**

Migrates more types in the config module to alloy and updates a bunch of references to these variables.