### PR TITLE
chore(l1): Migrate to Alloy

### DIFF
--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -69,7 +69,12 @@ impl Pipeline {
     }
 
     /// Sends [BatcherTransactions] & the L1 block they were received in to the [BatcherTransactions] receiver.
-    pub fn push_batcher_transactions(&self, txs: Vec<Bytes>, l1_origin: u64) -> Result<()> {
+    pub fn push_batcher_transactions(
+        &self,
+        txs: Vec<alloy_primitives::Bytes>,
+        l1_origin: u64,
+    ) -> Result<()> {
+        let txs = txs.into_iter().map(Bytes::from).collect();
         self.batcher_transaction_sender
             .send(BatcherTransactionMessage { txs, l1_origin })?;
         Ok(())

--- a/src/derive/stages/attributes.rs
+++ b/src/derive/stages/attributes.rs
@@ -99,7 +99,7 @@ impl Attributes {
 
         PayloadAttributes {
             timestamp,
-            prev_randao,
+            prev_randao: H256::from_slice(prev_randao.as_slice()),
             suggested_fee_recipient: Address::from_slice(suggested_fee_recipient.as_slice()),
             transactions,
             no_tx_pool: true,
@@ -336,8 +336,8 @@ impl AttributesDeposited {
         Self {
             number: l1_info.block_info.number,
             timestamp: l1_info.block_info.timestamp,
-            base_fee: l1_info.block_info.base_fee,
-            hash: l1_info.block_info.hash,
+            base_fee: U256::from_big_endian(&l1_info.block_info.base_fee.to_be_bytes::<32>()),
+            hash: H256::from_slice(l1_info.block_info.hash.as_slice()),
             sequence_number: seq,
             batcher_hash,
             fee_overhead,

--- a/src/derive/state.rs
+++ b/src/derive/state.rs
@@ -1,6 +1,5 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use alloy_primitives::B256;
 use ethers::{
     providers::{Http, Middleware, Provider},
     types::H256,
@@ -77,7 +76,7 @@ impl State {
     pub fn epoch_by_hash(&self, hash: H256) -> Option<Epoch> {
         self.l1_info_by_hash(hash).map(|info| Epoch {
             number: info.block_info.number,
-            hash: B256::from_slice(info.block_info.hash.as_bytes()),
+            hash: info.block_info.hash,
             timestamp: info.block_info.timestamp,
         })
     }
@@ -86,7 +85,7 @@ impl State {
     pub fn epoch_by_number(&self, num: u64) -> Option<Epoch> {
         self.l1_info_by_number(num).map(|info| Epoch {
             number: info.block_info.number,
-            hash: B256::from_slice(info.block_info.hash.as_bytes()),
+            hash: info.block_info.hash,
             timestamp: info.block_info.timestamp,
         })
     }
@@ -97,9 +96,14 @@ impl State {
     pub fn update_l1_info(&mut self, l1_info: L1Info) {
         self.current_epoch_num = l1_info.block_info.number;
 
-        self.l1_hashes
-            .insert(l1_info.block_info.number, l1_info.block_info.hash);
-        self.l1_info.insert(l1_info.block_info.hash, l1_info);
+        self.l1_hashes.insert(
+            l1_info.block_info.number,
+            H256::from_slice(l1_info.block_info.hash.as_slice()),
+        );
+        self.l1_info.insert(
+            H256::from_slice(l1_info.block_info.hash.as_slice()),
+            l1_info,
+        );
 
         self.prune();
     }

--- a/src/l1/blob_encoding.rs
+++ b/src/l1/blob_encoding.rs
@@ -1,4 +1,4 @@
-use bytes::Bytes;
+use alloy_primitives::Bytes;
 use eyre::Result;
 
 const MAX_BLOB_DATA_SIZE: usize = (4 * 31 + 3) * 1024 - 4;

--- a/src/l1/chain_watcher.rs
+++ b/src/l1/chain_watcher.rs
@@ -319,26 +319,17 @@ impl InnerWatcher {
                 let mut config = self.system_config;
                 match update {
                     SystemConfigUpdate::BatchSender(addr) => {
-                        config.batch_sender =
-                            alloy_primitives::Address::from_slice(addr.as_bytes());
+                        config.batch_sender = addr;
                     }
                     SystemConfigUpdate::Fees(overhead, scalar) => {
-                        let overhead_slice: &mut [u8] = &mut [0; 0];
-                        let scalar_slice: &mut [u8] = &mut [0; 0];
-                        overhead.to_big_endian(overhead_slice);
-                        scalar.to_big_endian(scalar_slice);
-                        config.l1_fee_overhead =
-                            alloy_primitives::U256::from_be_slice(overhead_slice);
-                        config.l1_fee_scalar = alloy_primitives::U256::from_be_slice(scalar_slice);
+                        config.l1_fee_overhead = overhead;
+                        config.l1_fee_scalar = scalar;
                     }
                     SystemConfigUpdate::Gas(gas) => {
-                        let gas_slice: &mut [u8] = &mut [0; 0];
-                        gas.to_big_endian(gas_slice);
-                        config.gas_limit = alloy_primitives::U256::from_be_slice(gas_slice);
+                        config.gas_limit = gas; 
                     }
                     SystemConfigUpdate::UnsafeBlockSigner(addr) => {
-                        config.unsafe_block_signer =
-                            alloy_primitives::Address::from_slice(addr.as_bytes());
+                        config.unsafe_block_signer = addr;
                     }
                 }
 

--- a/src/l1/chain_watcher.rs
+++ b/src/l1/chain_watcher.rs
@@ -269,7 +269,7 @@ impl InnerWatcher {
 
             if l1_info.block_info.number >= self.finalized_block {
                 let block_info = BlockInfo {
-                    hash: B256::from_slice(l1_info.block_info.hash.as_bytes()),
+                    hash: l1_info.block_info.hash,
                     number: l1_info.block_info.number,
                     timestamp: l1_info.block_info.timestamp,
                     parent_hash: B256::from_slice(block.header.parent_hash.as_slice()),
@@ -331,7 +331,7 @@ impl InnerWatcher {
                     }
                 }
 
-                let update_block: u64 = update_block.try_into()?;
+                let update_block: u64 = update_block;
                 self.system_config_update = (update_block, Some(config));
             } else {
                 self.system_config_update = (to_block, None);
@@ -368,27 +368,23 @@ impl InnerWatcher {
             true => BlockNumberOrTag::Latest,
         };
 
-        Ok(self
-            .provider
+        self.provider
             .get_block(BlockId::Number(block_number), false)
             .await?
             .ok_or(eyre::eyre!("block not found"))?
             .header
             .number
-            .ok_or(eyre::eyre!("block pending"))?
-            .try_into()?)
+            .ok_or(eyre::eyre!("block pending"))
     }
 
     async fn get_head(&self) -> Result<u64> {
-        Ok(self
-            .provider
+        self.provider
             .get_block(BlockId::Number(BlockNumberOrTag::Latest), false)
             .await?
             .ok_or(eyre::eyre!("block not found"))?
             .header
             .number
-            .ok_or(eyre::eyre!("block pending"))?
-            .try_into()?)
+            .ok_or(eyre::eyre!("block pending"))
     }
 
     async fn get_block(&self, block_num: u64) -> Result<Block> {
@@ -484,7 +480,7 @@ impl InnerWatcher {
             return Ok(batcher_transactions_data);
         }
 
-        let timestamp: u64 = block.header.timestamp.try_into()?;
+        let timestamp: u64 = block.header.timestamp;
         let slot = self.blob_fetcher.get_slot_from_time(timestamp).await?;
 
         // perf: fetch only the required indexes instead of all

--- a/src/l1/config_updates.rs
+++ b/src/l1/config_updates.rs
@@ -1,5 +1,6 @@
+use alloy_primitives::{Address, U256, U64};
+use alloy_rpc_types::Log;
 use eyre::Result;
-use alloy_primitives::{Address, U64, U256, Log};
 
 /// Represents a system config update event
 #[derive(Debug)]
@@ -18,27 +19,29 @@ impl TryFrom<Log> for SystemConfigUpdate {
     type Error = eyre::Report;
 
     fn try_from(log: Log) -> Result<Self> {
-        let version = U64::from_be_bytes(**log
-            .topics()
-            .get(1)
-            .ok_or(eyre::eyre!("invalid system config update"))?
+        let version = U64::from_be_bytes(
+            **log
+                .topics()
+                .get(1)
+                .ok_or(eyre::eyre!("invalid system config update"))?,
         );
 
         if !version.is_zero() {
             return Err(eyre::eyre!("invalid system config update"));
         }
 
-        let update_type = U64::from_be_bytes(**log
-            .topics()
-            .get(2)
-            .ok_or(eyre::eyre!("invalid system config update"))?
+        let update_type = U64::from_be_bytes(
+            **log
+                .topics()
+                .get(2)
+                .ok_or(eyre::eyre!("invalid system config update"))?,
         );
 
         let update_type: u64 = update_type.try_into()?;
         match update_type {
             0 => {
                 let addr_bytes = log
-                    .data
+                    .data()
                     .data
                     .get(76..96)
                     .ok_or(eyre::eyre!("invalid system config update"))?;
@@ -48,13 +51,13 @@ impl TryFrom<Log> for SystemConfigUpdate {
             }
             1 => {
                 let fee_overhead = log
-                    .data
+                    .data()
                     .data
                     .get(64..96)
                     .ok_or(eyre::eyre!("invalid system config update"))?;
 
                 let fee_scalar = log
-                    .data
+                    .data()
                     .data
                     .get(96..128)
                     .ok_or(eyre::eyre!("invalid system config update"))?;
@@ -68,7 +71,7 @@ impl TryFrom<Log> for SystemConfigUpdate {
             }
             2 => {
                 let gas_bytes = log
-                    .data
+                    .data()
                     .data
                     .get(64..96)
                     .ok_or(eyre::eyre!("invalid system config update"))?;
@@ -79,7 +82,7 @@ impl TryFrom<Log> for SystemConfigUpdate {
             }
             3 => {
                 let addr_bytes = log
-                    .data
+                    .data()
                     .data
                     .get(76..96)
                     .ok_or(eyre::eyre!("invalid system config update"))?;

--- a/src/l1/l1_info.rs
+++ b/src/l1/l1_info.rs
@@ -1,4 +1,5 @@
-use ethers::types::{Block, Transaction, H256, U256};
+use alloy_primitives::{B256, U256};
+use alloy_rpc_types::Block;
 
 use crate::{config::SystemConfig, derive::stages::attributes::UserDeposited};
 
@@ -25,30 +26,29 @@ pub struct L1BlockInfo {
     /// L1 block number
     pub number: u64,
     /// L1 block hash
-    pub hash: H256,
+    pub hash: B256,
     /// L1 block timestamp
     pub timestamp: u64,
     /// L1 base fee per gas
     pub base_fee: U256,
     /// L1 mix hash (prevrandao)
-    pub mix_hash: H256,
+    pub mix_hash: B256,
     /// Post-Ecotone beacon block root
-    pub parent_beacon_block_root: Option<H256>,
+    pub parent_beacon_block_root: Option<B256>,
 }
 
-impl TryFrom<&alloy_rpc_types::Block> for L1BlockInfo {
+impl TryFrom<&Block> for L1BlockInfo {
     type Error = eyre::Error;
 
     fn try_from(value: &alloy_rpc_types::Block) -> std::result::Result<Self, Self::Error> {
         let number = value
             .header
             .number
-            .ok_or(eyre::eyre!("block not included"))?
-            .try_into()?;
+            .ok_or(eyre::eyre!("block not included"))?;
 
         let hash = value.header.hash.ok_or(eyre::eyre!("block not included"))?;
 
-        let timestamp = value.header.timestamp.try_into()?;
+        let timestamp = value.header.timestamp;
 
         let base_fee = value
             .header
@@ -64,42 +64,9 @@ impl TryFrom<&alloy_rpc_types::Block> for L1BlockInfo {
 
         Ok(L1BlockInfo {
             number,
-            hash: H256::from_slice(&hash.as_slice()),
-            timestamp,
-            base_fee: base_fee.into(),
-            mix_hash: H256::from_slice(&mix_hash.as_slice()),
-            parent_beacon_block_root: parent_beacon_block_root
-                .map(|x| H256::from_slice(&x.as_slice())),
-        })
-    }
-}
-
-impl TryFrom<&Block<Transaction>> for L1BlockInfo {
-    type Error = eyre::Error;
-
-    fn try_from(value: &Block<Transaction>) -> std::result::Result<Self, Self::Error> {
-        let number = value
-            .number
-            .ok_or(eyre::eyre!("block not included"))?
-            .as_u64();
-
-        let hash = value.hash.ok_or(eyre::eyre!("block not included"))?;
-
-        let timestamp = value.timestamp.as_u64();
-
-        let base_fee = value
-            .base_fee_per_gas
-            .ok_or(eyre::eyre!("block is pre london"))?;
-
-        let mix_hash = value.mix_hash.ok_or(eyre::eyre!("block not included"))?;
-
-        let parent_beacon_block_root = value.parent_beacon_block_root;
-
-        Ok(L1BlockInfo {
-            number,
             hash,
             timestamp,
-            base_fee,
+            base_fee: U256::from(base_fee),
             mix_hash,
             parent_beacon_block_root,
         })


### PR DESCRIPTION
**Description**

Migrates the `l1` module to Alloy.

Two main concerns with this pr as it stands. Currently removed retrying from the l1 chain watcher provider since the `RetryClient` previously used is from `ethers` and I'm not seeing a good alternative. It also seems that the `reqwest::ClientBuilder` [does not offer a retry policy](https://github.com/seanmonstar/reqwest/issues/316).

The second concern is that the rpc `Log` type returned from the alloy provider does not hydrate the block information needed to construct the user deposit information. As in, it is missing the `l1 block number`, `l1 block hash`, and `log index` (within the block). As a work around, I've modified the log fetching to query each block's log set at a time so we can hydrate this information ourselves (assuming logs are returned in their canonical block ordering from the provider). It would be much more efficient for the provider to hydrate this data such that we can batch rpc requests. Especially since we currently set the range to be 1000 blocks starting at the provided block number.

**Metadata**

Fixes #233 