### PR TITLE
chore: remove deprecated networks: optimism-goerli and base-goerli

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Next copy `.env.default` to `.env`
 cp .env.default .env
 ```
 
-In the `.env` file, modify the `L1_RPC_URL` field to contain a valid Ethereum RPC. For the Optimism and Base testnets, this must be a Goerli RPC URL. This RPC can either be from a local node, or a provider such as Alchemy or Infura. 
+In the `.env` file, modify the `L1_RPC_URL` field to contain a valid Ethereum RPC. For the Optimism and Base testnets, this must be a Sepolia RPC URL. This RPC can either be from a local node, or a provider such as Alchemy or Infura. 
 
-By default, the `NETWORK` field in `.env` is `optimism-goerli`, however `base-goerli` is also supported.
+By default, the `NETWORK` field in `.env` is `optimism-sepolia`, however `base-sepolia` is also supported.
 
 Start the docker containers
 ```sh

--- a/docker/.env.default
+++ b/docker/.env.default
@@ -1,5 +1,5 @@
 # L1 network option: can be either 
-# `optimism`, `optimism-goerli`, `optimism-sepolia`, `base-goerli`, `custom` or `devnet`.
+# `optimism`, `optimism-sepolia`, `base`, `base-sepolia`, `custom` or `devnet`.
 NETWORK=optimism
 
 # The HTTP RPC endpoint of an L1 node
@@ -63,8 +63,8 @@ OP_CHALLENGER_SIGNER_KEY=a1742ee5f7898541224d6a91d9f3b34ad442e27bcb43223c01e47e5
 
 
 # --------------------- Only needed for testing locally ---------------------
-L1_TEST_RPC_URL=https://eth-goerli.g.alchemy.com/v2/<API_KEY>
-L2_TEST_RPC_URL=https://opt-goerli.g.alchemy.com/v2/<API_KEY>
+L1_TEST_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/<API_KEY>
+L2_TEST_RPC_URL=https://opt-sepolia.g.alchemy.com/v2/<API_KEY>
 
 
 # ------------------------------ Do not modify ------------------------------

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,11 +4,12 @@ This contains a simple docker setup for running magi and op-geth.
 
 ## Running
 
-Begin by copying `.env.default` to `.env`. You can set the network to sync to by changing the `NETWORK` value (supported options are optimism-goerli and base-goerli).
+Begin by copying `.env.default` to `.env`. You can set the network to sync to by changing the `NETWORK` value (supported options are optimism-sepolia and base-sepolia).
 Make sure to set the `L1_RPC_URL` value to a valid RPC URL for the L1 being used by the given network. If you are running in production, you may also want to set a secure `JWT_SECRET` value.
 You can create a new secret by running `openssl rand -hex 32`.
 
 To run both magi and op-geth together, run `docker compose up`. To run just op-geth without magi for local development, run `COMPOSE_PROFILES=no-magi docker compose up`
 
 ## Troubleshooting
+
 If you are getting `permission denied` errors when attempting to run `docker-compose`, try `sudo docker compose` instead. This is often required when running docker depending on how it was installed.

--- a/docker/start-op-challenger.sh
+++ b/docker/start-op-challenger.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 set -e
 
-if [ $NETWORK = "optimism-goerli" ]
+if [ $NETWORK = "optimism-sepolia" ]
 then
     DISPUTE_GAME_FACTORY=0x000000000000000000000000000000000000dEaD # TODO: Update after deployment
     L2_OUTPUT_ORACLE=0xE6Dfba0953616Bacab0c9A8ecb3a9BBa77FC15c0
-elif [ $NETWORK = "base-goerli" ]
+elif [ $NETWORK = "base-sepolia" ]
 then 
     DISPUTE_GAME_FACTORY=0x000000000000000000000000000000000000dEaD # TODO: Update after deployment
     L2_OUTPUT_ORACLE=0x2A35891ff30313CcFa6CE88dcf3858bb075A2298
 else
-    echo "Network not recognized. Available options are optimism-goerli and base-goerli"
+    echo "Network not recognized. Available options are optimism-sepolia and base-sepolia"
     exit 1
 fi
 

--- a/docker/start-op-erigon.sh
+++ b/docker/start-op-erigon.sh
@@ -3,21 +3,6 @@ set -e
 
 DATADIR=/data/erigon
 
-if [ $NETWORK = "optimism-goerli" ]
-then
-    if [ ! -d $DATADIR ]
-    then
-        # apk update && apk install tar
-        mkdir $DATADIR
-        wget "https://backup.goerli.op-erigon.testinprod.io" -O erigon.tar.gz
-        tar -zxvf erigon.tar.gz -C /tmp
-        mv /tmp/chaindata $DATADIR
-    fi
-else
-    echo "Network not recognized. Available option is optimism-goerli. Use op-geth for base-goerli"
-    exit 1
-fi
-
 echo $JWT_SECRET > jwtsecret.txt
 
 exec erigon \

--- a/docker/start-op-erigon.sh
+++ b/docker/start-op-erigon.sh
@@ -31,4 +31,4 @@ exec erigon \
     --authrpc.port=8551 \
     --authrpc.vhosts="*" \
     --authrpc.jwtsecret=/jwtsecret.txt \
-    --rollup.sequencerhttp="https://goerli.optimism.io" \
+    --rollup.sequencerhttp="https://sepolia.optimism.io" \

--- a/docker/start-op-geth.sh
+++ b/docker/start-op-geth.sh
@@ -24,29 +24,12 @@ then
         wget "https://raw.githubusercontent.com/base-org/node/main/mainnet/genesis-l2.json" -O ./genesis-l2.json
         geth init --datadir=$DATADIR ./genesis-l2.json
     fi
-elif [ $NETWORK = "optimism-goerli" ]
-then
-    CHAIN_ID=420
-    if [ ! -d $DATADIR ]
-    then
-        mkdir $DATADIR
-        wget "https://datadirs.optimism.io/goerli-bedrock.tar.zst" -P $DATADIR
-        zstd -cd $DATADIR/goerli-bedrock.tar.zst | tar xvf - -C $DATADIR
-    fi
 elif [ "$NETWORK" = "optimism-sepolia" ]
 then
     CHAIN_ID=11155420
     if [ ! -d "$DATADIR" ]
     then
         wget "https://storage.googleapis.com/oplabs-network-data/Sepolia/genesis.json" -O ./genesis-l2.json
-        geth init --datadir=$DATADIR ./genesis-l2.json
-    fi
-elif [ $NETWORK = "base-goerli" ]
-then
-    CHAIN_ID=84531
-    if [ ! -d $DATADIR ]
-    then
-        wget "https://raw.githubusercontent.com/base-org/node/main/goerli/genesis-l2.json" -O ./genesis-l2.json
         geth init --datadir=$DATADIR ./genesis-l2.json
     fi
 elif [ $NETWORK = "base-sepolia" ]
@@ -67,7 +50,7 @@ then
         geth init --datadir=$DATADIR ./genesis-l2-attached.json
     fi
 else
-    echo "Network not recognized. Available options are optimism-goerli and base-goerli"
+    echo "Network not recognized. Available options are optimsim, optimism-sepolia, base, base-sepolia, custom"
     exit 1
 fi
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,4 +118,4 @@ The [Config](../src/config/mod.rs) object contains the system configuration for 
 - `regolith_time`: Timestamp of the regolith hardfork.
 - `blocktime`: The L2 blocktime.
 
-The [ChainConfig](../src/config/mod.rs) contains default implementations for certain chains. For example, an `optimism-goerli` [ChainConfig](../src/config/mod.rs) instance can be created by calling `ChainConfig::optimism_goerli()`, and a `base-goerli` instance can be created by calling `ChainConfig::base_goerli()`.
+The [ChainConfig](../src/config/mod.rs) contains default implementations for certain chains. For example, an `optimism` [ChainConfig](../src/config/mod.rs) instance can be created by calling `ChainConfig::optimism()`, and a `base` instance can be created by calling `ChainConfig::base()`.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -278,15 +278,13 @@ impl ChainConfig {
     pub fn from_network_name(network: &str) -> Self {
         match network.to_lowercase().as_str() {
             "optimism" => Self::optimism(),
-            "optimism-goerli" => Self::optimism_goerli(),
             "optimism-sepolia" => Self::optimism_sepolia(),
             "base" => Self::base(),
-            "base-goerli" => Self::base_goerli(),
             "base-sepolia" => Self::base_sepolia(),
             file if file.ends_with(".json") => Self::from_json(file),
             _ => panic!(
                 "Invalid network name. \\
-            Please use one of the following: 'optimism', 'optimism-goerli', 'optimism-sepolia', 'base-goerli', 'base-sepolia', 'base'. \\
+            Please use one of the following: 'optimism', 'optimism-sepolia', 'base-sepolia', 'base'. \\
             You can also use a JSON file path for custom configuration."
             ),
         }
@@ -344,48 +342,6 @@ impl ChainConfig {
             canyon_time: 170499240,
             delta_time: 1708560000,
             ecotone_time: 1710781201,
-        }
-    }
-
-    /// [ChainConfig] for Optimism Goerli
-    pub fn optimism_goerli() -> Self {
-        Self {
-            network: "optimism-goerli".to_string(),
-            l1_chain_id: 5,
-            l2_chain_id: 420,
-            l1_start_epoch: Epoch {
-                hash: hash("0x6ffc1bf3754c01f6bb9fe057c1578b87a8571ce2e9be5ca14bace6eccfd336c7"),
-                number: 8300214,
-                timestamp: 1673550516,
-            },
-            l2_genesis: BlockInfo {
-                hash: hash("0x0f783549ea4313b784eadd9b8e8a69913b368b7366363ea814d7707ac505175f"),
-                number: 4061224,
-                parent_hash: hash(
-                    "0x31267a44f1422f4cab59b076548c075e79bd59e691a23fbce027f572a2a49dc9",
-                ),
-                timestamp: 1673550516,
-            },
-            system_config: SystemConfig {
-                batch_sender: addr("0x7431310e026b69bfc676c0013e12a1a11411eec9"),
-                gas_limit: U256::from(25_000_000),
-                l1_fee_overhead: U256::from(2100),
-                l1_fee_scalar: U256::from(1000000),
-                unsafe_block_signer: addr("0x715b7219D986641DF9eFd9C7Ef01218D528e19ec"),
-            },
-            system_config_contract: addr("0xAe851f927Ee40dE99aaBb7461C00f9622ab91d60"),
-            batch_inbox: addr("0xff00000000000000000000000000000000000420"),
-            deposit_contract: addr("0x5b47E1A08Ea6d985D6649300584e6722Ec4B1383"),
-            l2_to_l1_message_passer: addr("0xEF2ec5A5465f075E010BE70966a8667c94BCe15a"),
-            max_channel_size: 100_000_000,
-            channel_timeout: 300,
-            seq_window_size: 3600,
-            max_seq_drift: 600,
-            regolith_time: 1679079600,
-            canyon_time: 1699981200,
-            delta_time: 1703116800,
-            ecotone_time: 1707238800,
-            blocktime: 2,
         }
     }
 
@@ -468,46 +424,6 @@ impl ChainConfig {
             canyon_time: 1704992401,
             delta_time: 1708560000,
             ecotone_time: 1710781201,
-        }
-    }
-
-    /// [ChainConfig] for Base Goerli
-    pub fn base_goerli() -> Self {
-        Self {
-            network: "base-goerli".to_string(),
-            l1_chain_id: 5,
-            l2_chain_id: 84531,
-            l1_start_epoch: Epoch {
-                number: 8410981,
-                hash: hash("0x73d89754a1e0387b89520d989d3be9c37c1f32495a88faf1ea05c61121ab0d19"),
-                timestamp: 1675193616,
-            },
-            l2_genesis: BlockInfo {
-                hash: hash("0xa3ab140f15ea7f7443a4702da64c10314eb04d488e72974e02e2d728096b4f76"),
-                number: 0,
-                parent_hash: H256::zero(),
-                timestamp: 1675193616,
-            },
-            system_config: SystemConfig {
-                batch_sender: addr("0x2d679b567db6187c0c8323fa982cfb88b74dbcc7"),
-                gas_limit: U256::from(25_000_000),
-                l1_fee_overhead: U256::from(2100),
-                l1_fee_scalar: U256::from(1000000),
-                unsafe_block_signer: addr("0x32a4e99A72c11E9DD3dC159909a2D7BD86C1Bc51"),
-            },
-            system_config_contract: addr("0xb15eea247ece011c68a614e4a77ad648ff495bc1"),
-            batch_inbox: addr("0x8453100000000000000000000000000000000000"),
-            deposit_contract: addr("0xe93c8cd0d409341205a592f8c4ac1a5fe5585cfa"),
-            l2_to_l1_message_passer: addr("0x4200000000000000000000000000000000000016"),
-            max_channel_size: 100_000_000,
-            channel_timeout: 300,
-            seq_window_size: 3600,
-            max_seq_drift: 600,
-            regolith_time: 1683219600,
-            canyon_time: 1699981200,
-            delta_time: 1703116800,
-            ecotone_time: 1707238800,
-            blocktime: 2,
         }
     }
 

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -123,7 +123,7 @@ mod tests {
                 l1_rpc_url: rpc.to_string(),
                 l1_beacon_url: String::new(),
                 l2_rpc_url: l2_rpc.to_string(),
-                chain: ChainConfig::optimism_goerli(),
+                chain: ChainConfig::optimism_sepolia(),
                 l2_engine_url: String::new(),
                 jwt_secret: String::new(),
                 checkpoint_sync_url: None,

--- a/src/derive/stages/channels.rs
+++ b/src/derive/stages/channels.rs
@@ -412,7 +412,7 @@ mod tests {
             jwt_secret: String::new(),
             rpc_port: 9545,
             rpc_addr: "127.0.0.1".to_string(),
-            chain: ChainConfig::optimism_goerli(),
+            chain: ChainConfig::optimism_sepolia(),
             checkpoint_sync_url: None,
             devnet: false,
         };

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -400,7 +400,7 @@ mod tests {
                 rpc_addr: None,
                 devnet: false,
             };
-            let config = Config::new(&config_path, cli_config, ChainConfig::optimism_goerli());
+            let config = Config::new(&config_path, cli_config, ChainConfig::optimism_sepolia());
             let (_shutdown_sender, shutdown_recv) = channel(false);
 
             let block_id = BlockId::Number(BlockNumber::Finalized);

--- a/src/l1/chain_watcher.rs
+++ b/src/l1/chain_watcher.rs
@@ -554,8 +554,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_batcher_transactions() {
-        let Ok(l1_beacon_url) = std::env::var("L1_GOERLI_BEACON_RPC_URL") else {
-            println!("L1_GOERLI_BEACON_RPC_URL not set; skipping test");
+        let Ok(l1_beacon_url) = std::env::var("L1_TEST_BEACON_RPC_URL") else {
+            println!("L1_TEST_BEACON_RPC_URL not set; skipping test");
             return;
         };
         let Ok(l1_rpc_url) = std::env::var("L1_TEST_RPC_URL") else {
@@ -565,7 +565,7 @@ mod tests {
 
         let config = Arc::new(Config {
             l1_beacon_url,
-            chain: ChainConfig::optimism_goerli(),
+            chain: ChainConfig::optimism_sepolia(),
             ..Default::default()
         });
 

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -26,10 +26,10 @@ impl Version {
     }
 }
 
-impl ToString for Version {
+impl std::fmt::Display for Version {
     /// Formatted as: {name}{version}-{meta}
-    fn to_string(&self) -> String {
-        format!("{}{}-{}", self.name, self.version, self.meta)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}-{}", self.name, self.version, self.meta)
     }
 }
 


### PR DESCRIPTION
- Removed all references to `goerli` networks, as they have been deprecated in February. 🫡 
- Updated infra scripts and documentation references as well.

