### PR TITLE
fix: handle 0x prefix to jwt secret if it exists

### DIFF
--- a/src/engine/auth.rs
+++ b/src/engine/auth.rs
@@ -30,8 +30,17 @@ impl JwtSecret {
     /// The provided `secret` must be a valid hexadecimal string of length 64.
     pub fn from_hex<S: AsRef<str>>(hex: S) -> Result<Self> {
         let hex: &str = hex.as_ref().trim();
+        // Remove the "0x" or "0X" prefix if it exists
+        let hex = hex
+            .strip_prefix("0x")
+            .or_else(|| hex.strip_prefix("0X"))
+            .unwrap_or(hex);
         if hex.len() != JWT_SECRET_LEN {
-            Err(eyre::eyre!("Invalid JWT secret key length."))
+            Err(eyre::eyre!(
+                "Invalid JWT secret key length. Expected {} characters, got {}.",
+                JWT_SECRET_LEN,
+                hex.len()
+            ))
         } else {
             let hex_bytes = hex::decode(hex)?;
             let bytes = hex_bytes.try_into().expect("is expected len");


### PR DESCRIPTION
Closes https://github.com/a16z/magi/issues/245

The problem is that if the jwt secret starts with `0x` - and most clients generate the jwt secret with `0x` prefix - the length is `66` instead of `64` so it panics.

To solve it, I simply remove the prefix if it exists