### PR TITLE
Typo fix Update mod.rs

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -67,7 +67,7 @@ pub struct Config {
     pub checkpoint_sync_url: Option<String>,
     /// The port of the `Magi` RPC server
     pub rpc_port: u16,
-    /// The socket address of RPC server
+    /// The socket address of the RPC server
     pub rpc_addr: String,
     /// The devnet mode.
     /// If devnet is enabled.


### PR DESCRIPTION
### Description:

This update addresses a minor grammatical error in the documentation for the `rpc_addr` field of the `Config` struct. The original comment:

```rust
/// The socket address of RPC server
```

has been corrected to:

```rust
/// The socket address of the RPC server
```

The definite article "the" was missing before "RPC server," which is required for proper grammatical structure in English. While this change does not affect functionality, it improves clarity and ensures the documentation meets professional language standards. This is especially important for developers referencing the codebase, as clear and accurate comments facilitate understanding and reduce potential confusion.