### PR TITLE
Fix typo in attributes_deposited.rs

### DIFF
--- a/src/common/attributes_deposited.rs
+++ b/src/common/attributes_deposited.rs
@@ -5,7 +5,7 @@ use ethers::{
 use eyre::Result;
 use lazy_static::lazy_static;
 
-/// Represents the attributes deposited transcation call
+/// Represents the attributes deposited transaction call
 #[derive(Debug)]
 pub struct AttributesDepositedCall {
     /// block number


### PR DESCRIPTION
**Title:**  
Fix typo in attributes_deposited.rs: "transcation" → "transaction"

**Description:**  
This pull request corrects a minor typo in the documentation comment of the `AttributesDepositedCall` struct, changing "transcation" to "transaction" for improved clarity and professionalism. 